### PR TITLE
Iteration 2.5: Bridge Stacker

### DIFF
--- a/server/src/engine/__tests__/bridge-stacker.test.ts
+++ b/server/src/engine/__tests__/bridge-stacker.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from "vitest";
+import { computeBridgeStack, type BridgeStackInput } from "../bridge-stacker.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function bridge(name: string, value: number) {
+  return { name, effect: { type: "multiplier" as const, value } };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("computeBridgeStack", () => {
+  it("returns base threshold with no breakdown when bridges array is empty", () => {
+    const input: BridgeStackInput = {
+      base_threshold: 90,
+      actual_value: 50,
+      comparison_operator: "gte",
+      selected_bridges: [],
+    };
+
+    const result = computeBridgeStack(input);
+
+    expect(result.base_threshold).toBe(90);
+    expect(result.bridge_modifier_product).toBe(1);
+    expect(result.final_threshold).toBe(90);
+    expect(result.actual_value).toBe(50);
+    expect(result.passes).toBe(false); // 50 >= 90 is false
+    expect(result.breakdown).toEqual([]);
+  });
+
+  it("applies a single bridge multiplier correctly", () => {
+    const input: BridgeStackInput = {
+      base_threshold: 90,
+      actual_value: 50,
+      comparison_operator: "gte",
+      selected_bridges: [bridge("Sprinklers", 0.8)],
+    };
+
+    const result = computeBridgeStack(input);
+
+    expect(result.bridge_modifier_product).toBe(0.8);
+    expect(result.final_threshold).toBe(72); // 90 * 0.8
+    expect(result.passes).toBe(false); // 50 >= 72 is false
+  });
+
+  it("stacks two bridge multipliers so combined threshold passes", () => {
+    const input: BridgeStackInput = {
+      base_threshold: 90,
+      actual_value: 50,
+      comparison_operator: "gte",
+      selected_bridges: [bridge("Sprinklers", 0.8), bridge("Fire Barrier", 0.5)],
+    };
+
+    const result = computeBridgeStack(input);
+
+    expect(result.bridge_modifier_product).toBeCloseTo(0.4); // 0.8 * 0.5
+    expect(result.final_threshold).toBeCloseTo(36); // 90 * 0.4
+    expect(result.passes).toBe(true); // 50 >= 36
+  });
+
+  it("stacks three bridge multipliers correctly", () => {
+    const input: BridgeStackInput = {
+      base_threshold: 90,
+      actual_value: 50,
+      comparison_operator: "gte",
+      selected_bridges: [
+        bridge("Sprinklers", 0.8),
+        bridge("Fire Barrier", 0.75),
+        bridge("Setback", 0.5),
+      ],
+    };
+
+    const result = computeBridgeStack(input);
+
+    // 0.8 * 0.75 * 0.5 = 0.3
+    expect(result.bridge_modifier_product).toBeCloseTo(0.3);
+    // 90 * 0.3 = 27
+    expect(result.final_threshold).toBeCloseTo(27);
+    expect(result.passes).toBe(true); // 50 >= 27
+  });
+
+  it("produces correct running totals in the breakdown", () => {
+    const input: BridgeStackInput = {
+      base_threshold: 90,
+      actual_value: 50,
+      comparison_operator: "gte",
+      selected_bridges: [
+        bridge("Sprinklers", 0.8),
+        bridge("Fire Barrier", 0.75),
+        bridge("Setback", 0.5),
+      ],
+    };
+
+    const result = computeBridgeStack(input);
+
+    expect(result.breakdown).toEqual([
+      { bridge: "Sprinklers", modifier: 0.8, running_threshold: 72 },    // 90 * 0.8
+      { bridge: "Fire Barrier", modifier: 0.75, running_threshold: 54 }, // 72 * 0.75
+      { bridge: "Setback", modifier: 0.5, running_threshold: 27 },      // 54 * 0.5
+    ]);
+  });
+
+  it("uses strict greater-than when comparison_operator is 'gt'", () => {
+    // Exact boundary case: actual equals final threshold
+    const input: BridgeStackInput = {
+      base_threshold: 100,
+      actual_value: 50,
+      comparison_operator: "gt",
+      selected_bridges: [bridge("Sprinklers", 0.5)],
+    };
+
+    const result = computeBridgeStack(input);
+
+    expect(result.final_threshold).toBe(50); // 100 * 0.5
+    // 50 > 50 is false (strict)
+    expect(result.passes).toBe(false);
+
+    // Bump actual_value just above
+    const passingResult = computeBridgeStack({ ...input, actual_value: 50.01 });
+    expect(passingResult.passes).toBe(true);
+  });
+
+  it("handles gte at the exact boundary (actual equals final threshold)", () => {
+    const input: BridgeStackInput = {
+      base_threshold: 100,
+      actual_value: 50,
+      comparison_operator: "gte",
+      selected_bridges: [bridge("Sprinklers", 0.5)],
+    };
+
+    const result = computeBridgeStack(input);
+
+    // 50 >= 50 is true
+    expect(result.passes).toBe(true);
+  });
+});

--- a/server/src/engine/bridge-stacker.ts
+++ b/server/src/engine/bridge-stacker.ts
@@ -1,0 +1,87 @@
+import type {
+  BridgeStackBreakdown,
+  BridgeStackBreakdownItem,
+} from "@shared/types/evaluation.js";
+import type { BridgeEffect } from "@shared/types/rule.js";
+
+// ---------------------------------------------------------------------------
+// Input / Output types
+// ---------------------------------------------------------------------------
+
+export interface BridgeStackInput {
+  base_threshold: number;
+  actual_value: number;
+  comparison_operator: "gte" | "gt";
+  selected_bridges: Array<{
+    name: string;
+    effect: { type: "multiplier"; value: number };
+  }>;
+}
+
+export type BridgeStackResult = BridgeStackBreakdown;
+
+// ---------------------------------------------------------------------------
+// Core algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the stacked effect of one or more bridge mitigations on a
+ * numeric threshold.
+ *
+ * Each bridge carries a multiplier that is applied cumulatively to the
+ * base threshold.  The final (relaxed) threshold is then compared against
+ * the actual observed value using the supplied comparison operator.
+ *
+ * @example
+ *   // Two bridges relax the threshold: 90 * 0.8 * 0.5 = 36
+ *   computeBridgeStack({
+ *     base_threshold: 90,
+ *     actual_value: 50,
+ *     comparison_operator: "gte",
+ *     selected_bridges: [
+ *       { name: "Sprinklers",   effect: { type: "multiplier", value: 0.8 } },
+ *       { name: "Fire Barrier", effect: { type: "multiplier", value: 0.5 } },
+ *     ],
+ *   });
+ */
+export function computeBridgeStack(input: BridgeStackInput): BridgeStackResult {
+  const { base_threshold, actual_value, comparison_operator, selected_bridges } =
+    input;
+
+  // 1. Compute the cumulative modifier product
+  const bridge_modifier_product =
+    selected_bridges.length === 0
+      ? 1
+      : selected_bridges.reduce((product, b) => product * b.effect.value, 1);
+
+  // 2. Derive the final (relaxed) threshold
+  const final_threshold = base_threshold * bridge_modifier_product;
+
+  // 3. Build the per-bridge breakdown with running totals
+  const breakdown: BridgeStackBreakdownItem[] = [];
+  let running = base_threshold;
+
+  for (const bridge of selected_bridges) {
+    running = running * bridge.effect.value;
+    breakdown.push({
+      bridge: bridge.name,
+      modifier: bridge.effect.value,
+      running_threshold: running,
+    });
+  }
+
+  // 4. Evaluate the comparison
+  const passes =
+    comparison_operator === "gte"
+      ? actual_value >= final_threshold
+      : actual_value > final_threshold;
+
+  return {
+    base_threshold,
+    bridge_modifier_product,
+    final_threshold,
+    actual_value,
+    passes,
+    breakdown,
+  };
+}


### PR DESCRIPTION
## Summary
- `computeBridgeStack()` function: takes base threshold + selected bridge mitigations, returns stacked result with per-bridge breakdown
- Multiplicative stacking: final_threshold = base_threshold * product(bridge multipliers)
- Supports `gte` and `gt` comparison operators
- 7 unit tests covering: empty bridges, single, stacked (2 and 3), running totals, boundary cases

## Test Results
7/7 tests pass, TypeScript compiles clean.

## FRs/NFRs
FR-3.8 (multiplicative stacking), FR-3.9 (cumulative effect display), FR-3.5 (threshold changes)

Closes #12