### PR TITLE
Iteration 2.1: Evaluator interface and Registry

### DIFF
--- a/server/src/engine/__tests__/registry.test.ts
+++ b/server/src/engine/__tests__/registry.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import { EvaluatorRegistry } from "../registry.js";
+import { UnknownRuleTypeError } from "../errors.js";
+import type { Evaluator } from "../evaluator.interface.js";
+import type { EvalResult } from "../../../../shared/types/evaluation.js";
+import type { Rule } from "../../../../shared/types/rule.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal stub evaluator that returns a fixed EvalResult. */
+function createStubEvaluator(result: EvalResult): Evaluator {
+  return {
+    evaluate: vi.fn().mockReturnValue(result),
+    validate: vi.fn().mockReturnValue({ valid: true, errors: [] }),
+  };
+}
+
+/** Build a minimal Rule object for testing purposes. */
+function buildRule(overrides: Partial<Rule> = {}): Rule {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    name: "Test Rule",
+    description: "A rule used in unit tests",
+    type: "simple_threshold",
+    config: { field: "age", operator: "gte", value: 18 },
+    mitigations: [],
+    ...overrides,
+  } as Rule;
+}
+
+const TRIGGERED_RESULT: EvalResult = {
+  triggered: true,
+  details: {
+    observedValues: { age: 25 },
+    requiredValues: { field: "age", operator: "gte", value: 18 },
+    explanation: "age 25 >= 18",
+  },
+};
+
+const NOT_TRIGGERED_RESULT: EvalResult = {
+  triggered: false,
+  details: {
+    observedValues: { age: 10 },
+    requiredValues: { field: "age", operator: "gte", value: 18 },
+    explanation: "age 10 < 18",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvaluatorRegistry", () => {
+  it("registers and retrieves an evaluator", () => {
+    const registry = new EvaluatorRegistry();
+    const evaluator = createStubEvaluator(TRIGGERED_RESULT);
+
+    registry.register("simple_threshold", evaluator);
+
+    expect(registry.get("simple_threshold")).toBe(evaluator);
+  });
+
+  it("throws UnknownRuleTypeError for an unregistered type", () => {
+    const registry = new EvaluatorRegistry();
+
+    expect(() => registry.get("nonexistent_type")).toThrow(
+      UnknownRuleTypeError,
+    );
+    expect(() => registry.get("nonexistent_type")).toThrow(
+      /No evaluator registered for rule type: "nonexistent_type"/,
+    );
+  });
+
+  it("dispatches evaluate to the correct evaluator", () => {
+    const registry = new EvaluatorRegistry();
+    const simpleEvaluator = createStubEvaluator(TRIGGERED_RESULT);
+    const conditionalEvaluator = createStubEvaluator(NOT_TRIGGERED_RESULT);
+
+    registry.register("simple_threshold", simpleEvaluator);
+    registry.register("conditional_threshold", conditionalEvaluator);
+
+    const rule = buildRule({
+      type: "simple_threshold",
+      config: { field: "age", operator: "gte", value: 18 },
+    });
+    const observations = { age: 25 };
+
+    const { rule: returnedRule, result } = registry.evaluate(
+      rule,
+      observations,
+    );
+
+    expect(returnedRule).toBe(rule);
+    expect(result).toEqual(TRIGGERED_RESULT);
+    expect(simpleEvaluator.evaluate).toHaveBeenCalledWith(
+      rule.config,
+      observations,
+    );
+    expect(conditionalEvaluator.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("overwrites an existing evaluator when registering the same type", () => {
+    const registry = new EvaluatorRegistry();
+    const original = createStubEvaluator(TRIGGERED_RESULT);
+    const replacement = createStubEvaluator(NOT_TRIGGERED_RESULT);
+
+    registry.register("simple_threshold", original);
+    registry.register("simple_threshold", replacement);
+
+    expect(registry.get("simple_threshold")).toBe(replacement);
+
+    const rule = buildRule();
+    const { result } = registry.evaluate(rule, { age: 10 });
+
+    expect(result).toEqual(NOT_TRIGGERED_RESULT);
+    expect(replacement.evaluate).toHaveBeenCalled();
+    expect(original.evaluate).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/engine/errors.ts
+++ b/server/src/engine/errors.ts
@@ -1,0 +1,13 @@
+/**
+ * Thrown when the EvaluatorRegistry is asked for a rule type that has not been
+ * registered.
+ */
+export class UnknownRuleTypeError extends Error {
+  public readonly ruleType: string;
+
+  constructor(type: string) {
+    super(`No evaluator registered for rule type: "${type}"`);
+    this.name = "UnknownRuleTypeError";
+    this.ruleType = type;
+  }
+}

--- a/server/src/engine/evaluator.interface.ts
+++ b/server/src/engine/evaluator.interface.ts
@@ -1,0 +1,15 @@
+import type { EvalResult } from "../../../shared/types/evaluation.js";
+
+/**
+ * Contract that every rule-type evaluator must implement.
+ *
+ * `config` is typed as `any` because each evaluator narrows it internally to
+ * its specific configuration shape (SimpleConfig, ConditionalConfig, etc.).
+ */
+export interface Evaluator {
+  /** Run the evaluation logic and return a result. */
+  evaluate(config: any, observations: Record<string, any>): EvalResult;
+
+  /** Validate that `config` conforms to the expected shape for this evaluator. */
+  validate(config: unknown): { valid: boolean; errors: string[] };
+}

--- a/server/src/engine/registry.ts
+++ b/server/src/engine/registry.ts
@@ -1,0 +1,46 @@
+import type { EvalResult } from "../../../shared/types/evaluation.js";
+import type { Rule } from "../../../shared/types/rule.js";
+import type { Evaluator } from "./evaluator.interface.js";
+import { UnknownRuleTypeError } from "./errors.js";
+
+/**
+ * Central registry that maps rule type strings to their Evaluator
+ * implementations. The engine uses this to dispatch evaluation for any rule.
+ */
+export class EvaluatorRegistry {
+  private evaluators = new Map<string, Evaluator>();
+
+  /**
+   * Register an evaluator for the given rule type.
+   * If an evaluator is already registered for that type it will be replaced.
+   */
+  register(type: string, evaluator: Evaluator): void {
+    this.evaluators.set(type, evaluator);
+  }
+
+  /**
+   * Retrieve the evaluator for the given rule type.
+   * @throws {UnknownRuleTypeError} if no evaluator has been registered.
+   */
+  get(type: string): Evaluator {
+    const evaluator = this.evaluators.get(type);
+    if (!evaluator) {
+      throw new UnknownRuleTypeError(type);
+    }
+    return evaluator;
+  }
+
+  /**
+   * Convenience method: look up the correct evaluator for `rule.type`,
+   * run it against the provided observations, and return both the rule
+   * and its evaluation result.
+   */
+  evaluate(
+    rule: Rule,
+    observations: Record<string, any>,
+  ): { rule: Rule; result: EvalResult } {
+    const evaluator = this.get(rule.type);
+    const result = evaluator.evaluate(rule.config, observations);
+    return { rule, result };
+  }
+}


### PR DESCRIPTION
## Summary
- `Evaluator` interface with `evaluate()` and `validate()` methods
- `EvaluatorRegistry` class: register/get evaluators by type, dispatch via `evaluate(rule, observations)`
- `UnknownRuleTypeError` for unregistered rule types
- 4 unit tests (register/retrieve, unknown type error, dispatch, overwrite)

## Test Results
4/4 tests pass, TypeScript compiles clean.

## FRs/NFRs
FR-2.1 (evaluate against all rules), FR-2.3 (independent evaluation via registry dispatch)

Closes #8