### PR TITLE
Iteration 2.3: ConditionalThresholdEvaluator

### DIFF
--- a/server/src/engine/__tests__/conditional-threshold.evaluator.test.ts
+++ b/server/src/engine/__tests__/conditional-threshold.evaluator.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { ConditionalThresholdEvaluator } from "../evaluators/conditional-threshold.evaluator.js";
+import { ROOF_RULE } from "../../../../shared/data/seed-rules.js";
+import type { ConditionalConfig } from "../../../../shared/types/rule.js";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const evaluator = new ConditionalThresholdEvaluator();
+const config = ROOF_RULE.config as ConditionalConfig;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ConditionalThresholdEvaluator", () => {
+  // -----------------------------------------------------------------------
+  // 1. Risk A + Class A -> passes (condition branch, Class A in [A, B])
+  // -----------------------------------------------------------------------
+  it("passes when condition branch matches and threshold is met (Risk A + Class A)", () => {
+    const result = evaluator.evaluate(config, {
+      wildfire_risk_category: "A",
+      roof_type: "Class A",
+    });
+
+    expect(result.triggered).toBe(false);
+    expect(result.details.observedValues).toEqual({
+      wildfire_risk_category: "A",
+      roof_type: "Class A",
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Risk A + Class B -> passes (condition branch, Class B in [A, B])
+  // -----------------------------------------------------------------------
+  it("passes when condition branch matches and threshold is met (Risk A + Class B)", () => {
+    const result = evaluator.evaluate(config, {
+      wildfire_risk_category: "A",
+      roof_type: "Class B",
+    });
+
+    expect(result.triggered).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. Risk A + Class C -> triggers (condition branch, Class C not in [A, B])
+  // -----------------------------------------------------------------------
+  it("triggers when condition branch matches but threshold is NOT met (Risk A + Class C)", () => {
+    const result = evaluator.evaluate(config, {
+      wildfire_risk_category: "A",
+      roof_type: "Class C",
+    });
+
+    expect(result.triggered).toBe(true);
+    expect(result.details.explanation).toContain("Condition NOT met");
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. Risk B + Class A -> passes (default branch, eq Class A)
+  // -----------------------------------------------------------------------
+  it("passes when no condition matches and default threshold is met (Risk B + Class A)", () => {
+    const result = evaluator.evaluate(config, {
+      wildfire_risk_category: "B",
+      roof_type: "Class A",
+    });
+
+    expect(result.triggered).toBe(false);
+    expect(result.details.explanation).toContain("default");
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. Risk B + Class B -> triggers (default branch, Class B != Class A)
+  // -----------------------------------------------------------------------
+  it("triggers when no condition matches and default threshold is NOT met (Risk B + Class B)", () => {
+    const result = evaluator.evaluate(config, {
+      wildfire_risk_category: "B",
+      roof_type: "Class B",
+    });
+
+    expect(result.triggered).toBe(true);
+    expect(result.details.explanation).toContain("default");
+    expect(result.details.explanation).toContain("Condition NOT met");
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. Risk C + Class C -> triggers (default branch)
+  // -----------------------------------------------------------------------
+  it("triggers when no condition matches and default threshold is NOT met (Risk C + Class C)", () => {
+    const result = evaluator.evaluate(config, {
+      wildfire_risk_category: "C",
+      roof_type: "Class C",
+    });
+
+    expect(result.triggered).toBe(true);
+    expect(result.details.explanation).toContain("default");
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Explanation mentions which branch was evaluated
+  // -----------------------------------------------------------------------
+  it("includes the matched branch label in the explanation", () => {
+    const conditionResult = evaluator.evaluate(config, {
+      wildfire_risk_category: "A",
+      roof_type: "Class A",
+    });
+    expect(conditionResult.details.explanation).toContain("condition[0]");
+
+    const defaultResult = evaluator.evaluate(config, {
+      wildfire_risk_category: "B",
+      roof_type: "Class A",
+    });
+    expect(defaultResult.details.explanation).toContain("default");
+  });
+
+  // -----------------------------------------------------------------------
+  // 8. validate() rejects invalid config (empty conditions array)
+  // -----------------------------------------------------------------------
+  it("rejects invalid config with empty conditions array", () => {
+    const result = evaluator.validate({
+      conditions: [],
+      default: { field: "roof_type", operator: "eq", value: "Class A" },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // 9. validate() accepts valid config
+  // -----------------------------------------------------------------------
+  it("accepts a valid conditional config", () => {
+    const result = evaluator.validate(config);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // 10. validate() rejects config missing default
+  // -----------------------------------------------------------------------
+  it("rejects config missing the default threshold", () => {
+    const result = evaluator.validate({
+      conditions: [
+        {
+          when: { field: "risk", operator: "eq", value: "A" },
+          then: { field: "roof", operator: "eq", value: "Class A" },
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/engine/evaluators/conditional-threshold.evaluator.ts
+++ b/server/src/engine/evaluators/conditional-threshold.evaluator.ts
@@ -1,0 +1,170 @@
+import { ConditionalConfigSchema } from "../../../../shared/schemas/rule.schema.js";
+import type { EvalResult } from "../../../../shared/types/evaluation.js";
+import type { Evaluator } from "../evaluator.interface.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Operator = "eq" | "neq" | "in" | "gte" | "lte" | "gt" | "lt";
+
+interface ThresholdCheck {
+  field: string;
+  operator: Operator;
+  value: string | number | string[];
+}
+
+interface ConditionalBranch {
+  when: ThresholdCheck;
+  then: ThresholdCheck;
+}
+
+interface ConditionalConfig {
+  conditions: ConditionalBranch[];
+  default: ThresholdCheck;
+}
+
+// ---------------------------------------------------------------------------
+// Operator helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether the observed value **passes** the condition.
+ * Returns true when the condition is satisfied.
+ */
+function passes(
+  operator: Operator,
+  observed: unknown,
+  expected: string | number | string[],
+): boolean {
+  switch (operator) {
+    case "eq":
+      return observed === expected;
+    case "neq":
+      return observed !== expected;
+    case "in":
+      return Array.isArray(expected) && expected.includes(observed as string);
+    case "gte":
+      return typeof observed === "number" && observed >= (expected as number);
+    case "lte":
+      return typeof observed === "number" && observed <= (expected as number);
+    case "gt":
+      return typeof observed === "number" && observed > (expected as number);
+    case "lt":
+      return typeof observed === "number" && observed < (expected as number);
+    default:
+      return false;
+  }
+}
+
+/** Format a value for human-readable explanation text. */
+function formatValue(val: unknown): string {
+  if (Array.isArray(val)) {
+    return `[${val.map((v) => `"${v}"`).join(", ")}]`;
+  }
+  return typeof val === "string" ? `"${val}"` : String(val);
+}
+
+const OPERATOR_LABEL: Record<Operator, string> = {
+  eq: "==",
+  neq: "!=",
+  in: "in",
+  gte: ">=",
+  lte: "<=",
+  gt: ">",
+  lt: "<",
+};
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+export class ConditionalThresholdEvaluator implements Evaluator {
+  evaluate(config: any, observations: Record<string, any>): EvalResult {
+    const typedConfig = config as ConditionalConfig;
+
+    // Try each condition branch in order
+    for (let i = 0; i < typedConfig.conditions.length; i++) {
+      const branch = typedConfig.conditions[i];
+      const whenObserved = observations[branch.when.field];
+      const whenMatched = passes(
+        branch.when.operator,
+        whenObserved,
+        branch.when.value,
+      );
+
+      if (whenMatched) {
+        // This branch matched -- evaluate the "then" threshold
+        return this.evaluateThreshold(
+          branch.then,
+          observations,
+          `condition[${i}]`,
+          branch.when,
+          whenObserved,
+        );
+      }
+    }
+
+    // No branch matched -- use default threshold
+    return this.evaluateThreshold(
+      typedConfig.default,
+      observations,
+      "default",
+      undefined,
+      undefined,
+    );
+  }
+
+  validate(config: unknown): { valid: boolean; errors: string[] } {
+    const result = ConditionalConfigSchema.safeParse(config);
+    if (result.success) {
+      return { valid: true, errors: [] };
+    }
+    return {
+      valid: false,
+      errors: result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      ),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private evaluateThreshold(
+    threshold: ThresholdCheck,
+    observations: Record<string, any>,
+    branchLabel: string,
+    whenClause: ThresholdCheck | undefined,
+    whenObserved: unknown,
+  ): EvalResult {
+    const { field, operator, value } = threshold;
+    const observed = observations[field];
+    const conditionPassed = passes(operator, observed, value);
+
+    // Build explanation
+    const branchPart =
+      whenClause !== undefined
+        ? `Branch ${branchLabel} matched (${whenClause.field} ${formatValue(whenObserved)} ${OPERATOR_LABEL[whenClause.operator]} ${formatValue(whenClause.value)}). `
+        : `No condition branch matched; using ${branchLabel} threshold. `;
+
+    const checkPart = `${field} ${formatValue(observed)} ${OPERATOR_LABEL[operator]} ${formatValue(value)}: `;
+
+    const verdict = conditionPassed
+      ? "Condition met -- no vulnerability."
+      : "Condition NOT met -- vulnerability triggered.";
+
+    return {
+      triggered: !conditionPassed,
+      details: {
+        observedValues: {
+          ...(whenClause ? { [whenClause.field]: whenObserved } : {}),
+          [field]: observed,
+        },
+        requiredValues: { threshold, branch: branchLabel },
+        explanation: `${branchPart}${checkPart}${verdict}`,
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Evaluates when/then condition branches in order, falls back to default
- Reports which branch was evaluated in the explanation
- Handles all operators (eq, neq, in, gte, lte, gt, lt)
- validate() uses Zod ConditionalConfigSchema

## Test Results
All tests pass. TypeScript compiles clean.

## FRs/NFRs
FR-2.4.2, FR-2.5

Closes #10