### PR TITLE
Iteration 2.4: ComputedWithModifiersEvaluator

### DIFF
--- a/server/src/engine/__tests__/computed-with-modifiers.evaluator.test.ts
+++ b/server/src/engine/__tests__/computed-with-modifiers.evaluator.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from "vitest";
+import { ComputedWithModifiersEvaluator } from "../evaluators/computed-with-modifiers.evaluator.js";
+import type { ComputedConfig } from "../../../../shared/types/rule.js";
+
+// ---------------------------------------------------------------------------
+// Shared test config (mirrors WINDOWS_RULE.config from seed-rules)
+// ---------------------------------------------------------------------------
+
+const WINDOWS_CONFIG: ComputedConfig = {
+  baseValue: 30,
+  unit: "feet",
+  modifiers: [
+    {
+      field: "window_type",
+      operation: "multiply",
+      mapping: {
+        "Single Pane": 3,
+        "Double Pane": 2,
+        "Tempered Glass": 1,
+      },
+    },
+    {
+      field: "vegetation[].type",
+      operation: "divide",
+      mapping: {
+        Tree: 1,
+        Shrub: 2,
+        Grass: 3,
+      },
+    },
+  ],
+  comparisonField: "vegetation[].distance_to_window",
+  comparisonOperator: "gte",
+  arrayField: "vegetation",
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function buildObservations(
+  windowType: string,
+  vegetation: Array<{ type: string; distance_to_window: number }>,
+): Record<string, any> {
+  return {
+    property_id: "PROP-TEST",
+    window_type: windowType,
+    vegetation,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ComputedWithModifiersEvaluator", () => {
+  const evaluator = new ComputedWithModifiersEvaluator();
+
+  // -----------------------------------------------------------------------
+  // Test 1: Single Pane + Tree at 50ft -> triggers
+  // threshold = 30 * 3 / 1 = 90ft, 50 < 90 -> FAIL
+  // -----------------------------------------------------------------------
+  it("triggers for Single Pane + Tree at 50ft (threshold 90 > 50)", () => {
+    const observations = buildObservations("Single Pane", [
+      { type: "Tree", distance_to_window: 50 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(true);
+    expect(result.details.computedThreshold).toBe(90);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 2: Tempered Glass + Tree at 50ft -> passes
+  // threshold = 30 * 1 / 1 = 30ft, 50 >= 30 -> PASS
+  // -----------------------------------------------------------------------
+  it("passes for Tempered Glass + Tree at 50ft (threshold 30 <= 50)", () => {
+    const observations = buildObservations("Tempered Glass", [
+      { type: "Tree", distance_to_window: 50 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(false);
+    expect(result.details.computedThreshold).toBe(30);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 3: Single Pane + Shrub at 50ft -> passes
+  // threshold = 30 * 3 / 2 = 45ft, 50 >= 45 -> PASS
+  // -----------------------------------------------------------------------
+  it("passes for Single Pane + Shrub at 50ft (threshold 45 <= 50)", () => {
+    const observations = buildObservations("Single Pane", [
+      { type: "Shrub", distance_to_window: 50 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(false);
+    expect(result.details.computedThreshold).toBe(45);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 4: Single Pane + Grass at 50ft -> passes
+  // threshold = 30 * 3 / 3 = 30ft, 50 >= 30 -> PASS
+  // -----------------------------------------------------------------------
+  it("passes for Single Pane + Grass at 50ft (threshold 30 <= 50)", () => {
+    const observations = buildObservations("Single Pane", [
+      { type: "Grass", distance_to_window: 50 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(false);
+    expect(result.details.computedThreshold).toBe(30);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 5: Multiple vegetation - Tree at 50ft + Tree at 100ft, Single Pane
+  // First: threshold 90, 50 < 90 -> FAIL
+  // Second: threshold 90, 100 >= 90 -> PASS
+  // Rule triggers because first item fails
+  // -----------------------------------------------------------------------
+  it("triggers when any vegetation item fails (Tree at 50ft fails, Tree at 100ft passes)", () => {
+    const observations = buildObservations("Single Pane", [
+      { type: "Tree", distance_to_window: 50 },
+      { type: "Tree", distance_to_window: 100 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(true);
+
+    const breakdown = (result.details as any).itemBreakdown;
+    expect(breakdown).toHaveLength(2);
+    expect(breakdown[0].passes).toBe(false);
+    expect(breakdown[0].threshold).toBe(90);
+    expect(breakdown[0].actualValue).toBe(50);
+    expect(breakdown[1].passes).toBe(true);
+    expect(breakdown[1].threshold).toBe(90);
+    expect(breakdown[1].actualValue).toBe(100);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 6: Multiple vegetation - all pass -> rule passes
+  // -----------------------------------------------------------------------
+  it("passes when all vegetation items meet the threshold", () => {
+    const observations = buildObservations("Tempered Glass", [
+      { type: "Tree", distance_to_window: 50 },
+      { type: "Shrub", distance_to_window: 20 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(false);
+
+    const breakdown = (result.details as any).itemBreakdown;
+    // Tree: 30 * 1 / 1 = 30, 50 >= 30 -> pass
+    expect(breakdown[0].passes).toBe(true);
+    expect(breakdown[0].threshold).toBe(30);
+    // Shrub: 30 * 1 / 2 = 15, 20 >= 15 -> pass
+    expect(breakdown[1].passes).toBe(true);
+    expect(breakdown[1].threshold).toBe(15);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 7: Double Pane + Tree at 50ft -> triggers
+  // threshold = 30 * 2 / 1 = 60ft, 50 < 60 -> FAIL
+  // -----------------------------------------------------------------------
+  it("triggers for Double Pane + Tree at 50ft (threshold 60 > 50)", () => {
+    const observations = buildObservations("Double Pane", [
+      { type: "Tree", distance_to_window: 50 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.triggered).toBe(true);
+    expect(result.details.computedThreshold).toBe(60);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 8: Computation details include full breakdown
+  // -----------------------------------------------------------------------
+  it("includes computation breakdown with base value, modifiers, threshold, and actual value", () => {
+    const observations = buildObservations("Single Pane", [
+      { type: "Tree", distance_to_window: 50 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    expect(result.details.computedThreshold).toBe(90);
+    expect(result.details.requiredValues).toEqual({
+      baseValue: 30,
+      unit: "feet",
+      comparisonOperator: "gte",
+    });
+
+    const breakdown = (result.details as any).itemBreakdown;
+    expect(breakdown).toHaveLength(1);
+
+    const item = breakdown[0];
+    expect(item.observationModifierProduct).toBe(3); // 3 * (1/1)
+    expect(item.threshold).toBe(90);
+    expect(item.actualValue).toBe(50);
+    expect(item.passes).toBe(false);
+    expect(item.modifiers).toEqual([
+      {
+        field: "window_type",
+        observedValue: "Single Pane",
+        mappedValue: 3,
+        operation: "multiply",
+      },
+      {
+        field: "vegetation[].type",
+        observedValue: "Tree",
+        mappedValue: 1,
+        operation: "divide",
+      },
+    ]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 9: validate() rejects invalid config
+  // -----------------------------------------------------------------------
+  it("rejects invalid config via validate()", () => {
+    const invalidConfig = {
+      baseValue: -10, // must be positive
+      // missing required fields
+    };
+
+    const validation = evaluator.validate(invalidConfig);
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors.length).toBeGreaterThan(0);
+  });
+
+  it("accepts valid config via validate()", () => {
+    const validation = evaluator.validate(WINDOWS_CONFIG);
+
+    expect(validation.valid).toBe(true);
+    expect(validation.errors).toEqual([]);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 10: Mixed vegetation types get different modifier values
+  // Tree + Shrub with Single Pane
+  // Tree: 30 * 3 / 1 = 90, Shrub: 30 * 3 / 2 = 45
+  // -----------------------------------------------------------------------
+  it("handles mixed vegetation types with different modifier values per item", () => {
+    const observations = buildObservations("Single Pane", [
+      { type: "Tree", distance_to_window: 80 },
+      { type: "Shrub", distance_to_window: 40 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    const breakdown = (result.details as any).itemBreakdown;
+    expect(breakdown).toHaveLength(2);
+
+    // Tree item: threshold = 30 * 3 / 1 = 90, 80 < 90 -> fails
+    expect(breakdown[0].threshold).toBe(90);
+    expect(breakdown[0].actualValue).toBe(80);
+    expect(breakdown[0].passes).toBe(false);
+
+    // Shrub item: threshold = 30 * 3 / 2 = 45, 40 < 45 -> fails
+    expect(breakdown[1].threshold).toBe(45);
+    expect(breakdown[1].actualValue).toBe(40);
+    expect(breakdown[1].passes).toBe(false);
+
+    expect(result.triggered).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 11: Non-array mode (no arrayField set)
+  // -----------------------------------------------------------------------
+  it("evaluates non-array config by reading directly from observations", () => {
+    const nonArrayConfig: ComputedConfig = {
+      baseValue: 100,
+      unit: "feet",
+      modifiers: [
+        {
+          field: "risk_level",
+          operation: "multiply",
+          mapping: { High: 2, Low: 1 },
+        },
+      ],
+      comparisonField: "distance",
+      comparisonOperator: "gte",
+    };
+
+    const observations = { risk_level: "High", distance: 150 };
+    const result = evaluator.evaluate(nonArrayConfig, observations);
+
+    // threshold = 100 * 2 = 200, 150 < 200 -> triggered
+    expect(result.triggered).toBe(true);
+    expect(result.details.computedThreshold).toBe(200);
+  });
+
+  // -----------------------------------------------------------------------
+  // Test 12: Boundary case -- exact threshold with gte passes
+  // -----------------------------------------------------------------------
+  it("passes when actual value exactly equals threshold with gte operator", () => {
+    const observations = buildObservations("Tempered Glass", [
+      { type: "Tree", distance_to_window: 30 },
+    ]);
+
+    const result = evaluator.evaluate(WINDOWS_CONFIG, observations);
+
+    // threshold = 30 * 1 / 1 = 30, 30 >= 30 -> PASS
+    expect(result.triggered).toBe(false);
+  });
+});

--- a/server/src/engine/evaluators/computed-with-modifiers.evaluator.ts
+++ b/server/src/engine/evaluators/computed-with-modifiers.evaluator.ts
@@ -1,0 +1,237 @@
+import { ComputedConfigSchema } from "../../../../shared/schemas/rule.schema.js";
+import type { EvalResult } from "../../../../shared/types/evaluation.js";
+import type { ComputedConfig, Modifier } from "../../../../shared/types/rule.js";
+import type { Evaluator } from "../evaluator.interface.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ItemComputationDetail {
+  item: Record<string, any>;
+  modifiers: Array<{
+    field: string;
+    observedValue: string;
+    mappedValue: number;
+    operation: "multiply" | "divide";
+  }>;
+  observationModifierProduct: number;
+  threshold: number;
+  actualValue: number;
+  passes: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a modifier's value from either the current array item or the
+ * top-level observations, depending on whether the field contains "[]."
+ */
+function resolveModifierValue(
+  modifier: Modifier,
+  observations: Record<string, any>,
+  arrayItem?: Record<string, any>,
+): string {
+  if (modifier.field.includes("[].")) {
+    // Array-scoped field -- read from the current item
+    const property = modifier.field.split("[].")[1];
+    return arrayItem ? String(arrayItem[property]) : "";
+  }
+  // Top-level observation field
+  return String(observations[modifier.field]);
+}
+
+/**
+ * Resolve the comparison value from either the array item or top-level
+ * observations based on the comparisonField format.
+ */
+function resolveComparisonValue(
+  comparisonField: string,
+  observations: Record<string, any>,
+  arrayItem?: Record<string, any>,
+): number {
+  if (comparisonField.includes("[].")) {
+    const property = comparisonField.split("[].")[1];
+    return arrayItem ? Number(arrayItem[property]) : 0;
+  }
+  return Number(observations[comparisonField]);
+}
+
+/**
+ * Compare using the specified operator.
+ * The passing condition is: actualValue <operator> threshold.
+ */
+function compare(
+  operator: "gte" | "gt",
+  actualValue: number,
+  threshold: number,
+): boolean {
+  return operator === "gte"
+    ? actualValue >= threshold
+    : actualValue > threshold;
+}
+
+/**
+ * Compute modifiers and threshold for a single evaluation target
+ * (either a single observation set or one array item).
+ */
+function computeForItem(
+  config: ComputedConfig,
+  observations: Record<string, any>,
+  arrayItem?: Record<string, any>,
+): ItemComputationDetail {
+  const modifierDetails: ItemComputationDetail["modifiers"] = [];
+  let observationModifierProduct = 1.0;
+
+  for (const modifier of config.modifiers) {
+    const observedValue = resolveModifierValue(modifier, observations, arrayItem);
+    const mappedValue = modifier.mapping[observedValue];
+
+    if (mappedValue === undefined) {
+      // If the observed value has no mapping entry, skip this modifier
+      // (use neutral value of 1)
+      modifierDetails.push({
+        field: modifier.field,
+        observedValue,
+        mappedValue: 1,
+        operation: modifier.operation,
+      });
+      continue;
+    }
+
+    if (modifier.operation === "multiply") {
+      observationModifierProduct *= mappedValue;
+    } else {
+      observationModifierProduct /= mappedValue;
+    }
+
+    modifierDetails.push({
+      field: modifier.field,
+      observedValue,
+      mappedValue,
+      operation: modifier.operation,
+    });
+  }
+
+  const threshold = config.baseValue * observationModifierProduct;
+  const actualValue = resolveComparisonValue(
+    config.comparisonField,
+    observations,
+    arrayItem,
+  );
+  const passes = compare(config.comparisonOperator, actualValue, threshold);
+
+  return {
+    item: arrayItem ?? observations,
+    modifiers: modifierDetails,
+    observationModifierProduct,
+    threshold,
+    actualValue,
+    passes,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+export class ComputedWithModifiersEvaluator implements Evaluator {
+  evaluate(config: ComputedConfig, observations: Record<string, any>): EvalResult {
+    // Array-based evaluation
+    if (config.arrayField) {
+      const array: Record<string, any>[] = observations[config.arrayField] ?? [];
+      const itemResults: ItemComputationDetail[] = [];
+
+      for (const item of array) {
+        itemResults.push(computeForItem(config, observations, item));
+      }
+
+      // Rule triggers if ANY item fails
+      const anyFailed = itemResults.some((r) => !r.passes);
+
+      const failedItems = itemResults.filter((r) => !r.passes);
+      const explanation = anyFailed
+        ? `${failedItems.length} of ${itemResults.length} ${config.arrayField} item(s) failed the threshold check.`
+        : `All ${itemResults.length} ${config.arrayField} item(s) passed the threshold check.`;
+
+      return {
+        triggered: anyFailed,
+        details: {
+          observedValues: {
+            [config.arrayField]: array,
+            ...this.extractTopLevelObservedValues(config, observations),
+          },
+          requiredValues: {
+            baseValue: config.baseValue,
+            unit: config.unit,
+            comparisonOperator: config.comparisonOperator,
+          },
+          explanation,
+          computedThreshold: itemResults.length > 0
+            ? itemResults[0].threshold
+            : config.baseValue,
+          itemBreakdown: itemResults.map((r) => ({
+            item: r.item,
+            modifiers: r.modifiers,
+            observationModifierProduct: r.observationModifierProduct,
+            threshold: r.threshold,
+            actualValue: r.actualValue,
+            passes: r.passes,
+          })),
+        } as EvalResult["details"],
+      };
+    }
+
+    // Non-array evaluation
+    const result = computeForItem(config, observations);
+
+    const explanation = result.passes
+      ? `${config.comparisonField} ${result.actualValue} ${config.comparisonOperator === "gte" ? ">=" : ">"} ${result.threshold} ${config.unit}: Condition met -- no vulnerability.`
+      : `${config.comparisonField} ${result.actualValue} ${config.comparisonOperator === "gte" ? "<" : "<="} ${result.threshold} ${config.unit}: Condition NOT met -- vulnerability triggered.`;
+
+    return {
+      triggered: !result.passes,
+      details: {
+        observedValues: this.extractTopLevelObservedValues(config, observations),
+        requiredValues: {
+          baseValue: config.baseValue,
+          unit: config.unit,
+          comparisonOperator: config.comparisonOperator,
+        },
+        computedThreshold: result.threshold,
+        explanation,
+      },
+    };
+  }
+
+  validate(config: unknown): { valid: boolean; errors: string[] } {
+    const result = ComputedConfigSchema.safeParse(config);
+    if (result.success) {
+      return { valid: true, errors: [] };
+    }
+    return {
+      valid: false,
+      errors: result.error.issues.map(
+        (issue) => `${issue.path.join(".")}: ${issue.message}`,
+      ),
+    };
+  }
+
+  /**
+   * Extract top-level observation values referenced by non-array modifiers.
+   */
+  private extractTopLevelObservedValues(
+    config: ComputedConfig,
+    observations: Record<string, any>,
+  ): Record<string, any> {
+    const values: Record<string, any> = {};
+    for (const modifier of config.modifiers) {
+      if (!modifier.field.includes("[]")) {
+        values[modifier.field] = observations[modifier.field];
+      }
+    }
+    return values;
+  }
+}


### PR DESCRIPTION
## Summary
- Computes threshold = baseValue * product(modifiers), supports multiply and divide
- Array field support: per-item evaluation, triggers if ANY item fails
- Modifier field resolution: `vegetation[].type` from array item, `window_type` from top-level
- Returns per-item breakdown with modifier details
- 13 unit tests covering all window/vegetation combinations

## Test Results
13/13 tests pass. TypeScript compiles clean.

## FRs/NFRs
FR-2.4.3, FR-3.5

Closes #11