### PR TITLE
Iteration 2.6: Main evaluate() function

### DIFF
--- a/server/src/engine/__tests__/engine.test.ts
+++ b/server/src/engine/__tests__/engine.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest";
+import { evaluate } from "../engine.js";
+import {
+  SEED_RULES,
+  ATTIC_VENT_RULE,
+  ROOF_RULE,
+  WINDOWS_RULE,
+  HOME_TO_HOME_RULE,
+} from "../../../../shared/data/seed-rules.js";
+import {
+  OBS_ALL_PASSING,
+  OBS_ATTIC_VENT_FAIL,
+  OBS_WINDOWS_FAIL,
+  OBS_AUTO_DECLINE,
+  OBS_MULTIPLE_FAILS,
+} from "../../../../shared/data/seed-observations.js";
+
+// ---------------------------------------------------------------------------
+// Integration tests: evaluate() with seed rules and seed observations
+// ---------------------------------------------------------------------------
+
+describe("evaluate() -- integration tests", () => {
+  // -------------------------------------------------------------------------
+  // 1. OBS_ALL_PASSING: 0 vulnerabilities, auto_declined = false
+  // -------------------------------------------------------------------------
+
+  it("returns 0 vulnerabilities when all rules pass", () => {
+    const result = evaluate(OBS_ALL_PASSING, SEED_RULES);
+
+    expect(result.vulnerabilities).toHaveLength(0);
+    expect(result.auto_declined).toBe(false);
+    expect(result.summary.total_vulnerabilities).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. OBS_ATTIC_VENT_FAIL: 1 vulnerability (Attic Vent), has mitigations
+  // -------------------------------------------------------------------------
+
+  it("identifies Attic Vent vulnerability with mitigations, not auto-declined", () => {
+    const result = evaluate(OBS_ATTIC_VENT_FAIL, SEED_RULES);
+
+    expect(result.vulnerabilities).toHaveLength(1);
+    expect(result.vulnerabilities[0].rule_name).toBe("Attic Vent");
+    expect(result.vulnerabilities[0].triggered).toBe(true);
+    expect(result.vulnerabilities[0].mitigations.length).toBeGreaterThan(0);
+    expect(result.auto_declined).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. OBS_WINDOWS_FAIL: 1 vulnerability (Windows), has full + bridge
+  // -------------------------------------------------------------------------
+
+  it("identifies Window Safety Distance vulnerability with full and bridge mitigations", () => {
+    const result = evaluate(OBS_WINDOWS_FAIL, SEED_RULES);
+
+    const windowVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Window Safety Distance",
+    );
+    expect(windowVuln).toBeDefined();
+    expect(windowVuln!.triggered).toBe(true);
+
+    const fullMitigations = windowVuln!.mitigations.filter(
+      (m) => m.category === "full",
+    );
+    const bridgeMitigations = windowVuln!.mitigations.filter(
+      (m) => m.category === "bridge",
+    );
+    expect(fullMitigations.length).toBeGreaterThan(0);
+    expect(bridgeMitigations.length).toBeGreaterThan(0);
+    expect(result.auto_declined).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. OBS_AUTO_DECLINE: auto_declined = true, Home-to-Home identified
+  // -------------------------------------------------------------------------
+
+  it("marks auto_declined when Home-to-Home triggers with empty mitigations", () => {
+    const result = evaluate(OBS_AUTO_DECLINE, SEED_RULES);
+
+    expect(result.auto_declined).toBe(true);
+
+    const homeVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Home-to-Home Distance",
+    );
+    expect(homeVuln).toBeDefined();
+    expect(homeVuln!.triggered).toBe(true);
+    expect(homeVuln!.mitigations).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. OBS_MULTIPLE_FAILS: 3 vulnerabilities (Attic Vent + Roof + Windows)
+  // -------------------------------------------------------------------------
+
+  it("identifies multiple vulnerabilities (Attic Vent + Roof + Windows)", () => {
+    const result = evaluate(OBS_MULTIPLE_FAILS, SEED_RULES);
+
+    expect(result.vulnerabilities).toHaveLength(3);
+
+    const vulnNames = result.vulnerabilities.map((v) => v.rule_name).sort();
+    expect(vulnNames).toEqual(
+      ["Attic Vent", "Roof", "Window Safety Distance"].sort(),
+    );
+    expect(result.auto_declined).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. Missing globally required field: validation error, no evaluation
+  // -------------------------------------------------------------------------
+
+  it("returns validation error when property_id is missing", () => {
+    const { property_id, ...missingPropId } = OBS_ALL_PASSING;
+    const result = evaluate(missingPropId, SEED_RULES) as any;
+
+    expect(result.validation_error).toBeDefined();
+    expect(result.validation_error.missingFields).toContain("property_id");
+    expect(result.vulnerabilities).toHaveLength(0);
+    expect(result.skipped_rules).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 7. Missing rule-referenced field: Attic Vent skipped, others evaluated
+  // -------------------------------------------------------------------------
+
+  it("skips Attic Vent rule when attic_vent_screens is missing", () => {
+    const { attic_vent_screens, ...obs } = OBS_ALL_PASSING;
+    const result = evaluate(obs, SEED_RULES);
+
+    const skippedAttic = result.skipped_rules.find(
+      (s) => s.rule_name === "Attic Vent",
+    );
+    expect(skippedAttic).toBeDefined();
+    expect(skippedAttic!.missingFields).toContain("attic_vent_screens");
+
+    // Other rules should still be evaluated (not skipped)
+    expect(
+      result.skipped_rules.filter((s) => s.rule_name !== "Attic Vent"),
+    ).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 8. Missing array field: Windows rule skipped, others evaluated
+  // -------------------------------------------------------------------------
+
+  it("skips Windows rule when vegetation array is missing", () => {
+    const { vegetation, ...obs } = OBS_ALL_PASSING;
+    const result = evaluate(obs, SEED_RULES);
+
+    const skippedWindows = result.skipped_rules.find(
+      (s) => s.rule_name === "Window Safety Distance",
+    );
+    expect(skippedWindows).toBeDefined();
+    expect(skippedWindows!.missingFields).toContain("vegetation");
+
+    // Other rules should still evaluate normally
+    const evaluated = result.vulnerabilities.filter(
+      (v) => v.status === "evaluated",
+    );
+    // All non-windows rules should evaluate (not show as skipped)
+    expect(
+      result.skipped_rules.every(
+        (s) => s.rule_name === "Window Safety Distance",
+      ),
+    ).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // 9. Determinism: same input produces identical output
+  // -------------------------------------------------------------------------
+
+  it("produces deterministic results (except evaluation_id)", () => {
+    const result1 = evaluate(OBS_MULTIPLE_FAILS, SEED_RULES);
+    const result2 = evaluate(OBS_MULTIPLE_FAILS, SEED_RULES);
+
+    // evaluation_id is random, so exclude it for comparison
+    const { evaluation_id: _id1, ...rest1 } = result1;
+    const { evaluation_id: _id2, ...rest2 } = result2;
+
+    expect(rest1).toEqual(rest2);
+  });
+
+  // -------------------------------------------------------------------------
+  // 10. Summary counts are correct for each scenario
+  // -------------------------------------------------------------------------
+
+  it("produces correct summary counts for all passing", () => {
+    const result = evaluate(OBS_ALL_PASSING, SEED_RULES);
+
+    expect(result.summary.total_vulnerabilities).toBe(0);
+    expect(result.summary.auto_decline_vulnerabilities).toBe(0);
+    expect(result.summary.mitigatable).toBe(0);
+    expect(result.summary.bridge_mitigations_available).toBe(0);
+  });
+
+  it("produces correct summary counts for multiple failures", () => {
+    const result = evaluate(OBS_MULTIPLE_FAILS, SEED_RULES);
+
+    expect(result.summary.total_vulnerabilities).toBe(3);
+    expect(result.summary.auto_decline_vulnerabilities).toBe(0);
+    expect(result.summary.mitigatable).toBe(3);
+    // Windows rule has 3 bridge mitigations
+    expect(result.summary.bridge_mitigations_available).toBe(3);
+  });
+
+  it("produces correct summary counts for auto-decline", () => {
+    const result = evaluate(OBS_AUTO_DECLINE, SEED_RULES);
+
+    expect(result.summary.auto_decline_vulnerabilities).toBe(1);
+    expect(result.summary.total_vulnerabilities).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 11. Each vulnerability includes the rule's mitigations
+  // -------------------------------------------------------------------------
+
+  it("attaches the correct mitigations to each vulnerability", () => {
+    const result = evaluate(OBS_MULTIPLE_FAILS, SEED_RULES);
+
+    const atticVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Attic Vent",
+    );
+    expect(atticVuln!.mitigations).toEqual(ATTIC_VENT_RULE.mitigations);
+
+    const roofVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Roof",
+    );
+    expect(roofVuln!.mitigations).toEqual(ROOF_RULE.mitigations);
+
+    const windowsVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Window Safety Distance",
+    );
+    expect(windowsVuln!.mitigations).toEqual(WINDOWS_RULE.mitigations);
+  });
+
+  // -------------------------------------------------------------------------
+  // 12. Auto-declined result still shows other vulnerabilities
+  // -------------------------------------------------------------------------
+
+  it("shows all vulnerabilities even when auto-declined", () => {
+    // Use observations that trigger both Home-to-Home (auto-decline) and Attic Vent
+    const obs = {
+      ...OBS_AUTO_DECLINE,
+      attic_vent_screens: "Standard", // triggers Attic Vent too
+    };
+    const result = evaluate(obs, SEED_RULES);
+
+    expect(result.auto_declined).toBe(true);
+    // Should have at least Home-to-Home + Attic Vent
+    expect(result.vulnerabilities.length).toBeGreaterThanOrEqual(2);
+
+    const homeVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Home-to-Home Distance",
+    );
+    const atticVuln = result.vulnerabilities.find(
+      (v) => v.rule_name === "Attic Vent",
+    );
+    expect(homeVuln).toBeDefined();
+    expect(atticVuln).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 13. Skipped rules include reason and missing field names
+  // -------------------------------------------------------------------------
+
+  it("includes reason and missing field names in skipped rules", () => {
+    const { attic_vent_screens, vegetation, ...obs } = OBS_ALL_PASSING;
+    const result = evaluate(obs, SEED_RULES);
+
+    expect(result.skipped_rules.length).toBeGreaterThanOrEqual(2);
+
+    for (const skipped of result.skipped_rules) {
+      expect(skipped.reason).toBeTruthy();
+      expect(skipped.reason).toContain("Missing");
+      expect(skipped.missingFields.length).toBeGreaterThan(0);
+      expect(skipped.rule_id).toBeTruthy();
+      expect(skipped.rule_name).toBeTruthy();
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 14. Empty rules array: 0 vulnerabilities, not auto-declined
+  // -------------------------------------------------------------------------
+
+  it("returns 0 vulnerabilities and not auto-declined for empty rules array", () => {
+    const result = evaluate(OBS_ALL_PASSING, []);
+
+    expect(result.vulnerabilities).toHaveLength(0);
+    expect(result.skipped_rules).toHaveLength(0);
+    expect(result.auto_declined).toBe(false);
+    expect(result.summary.total_vulnerabilities).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 15. Performance: evaluating 4 rules < 10ms
+  // -------------------------------------------------------------------------
+
+  it("evaluates 4 seed rules in under 10ms", () => {
+    // Warm up
+    evaluate(OBS_ALL_PASSING, SEED_RULES);
+
+    const start = performance.now();
+    evaluate(OBS_MULTIPLE_FAILS, SEED_RULES);
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(10);
+  });
+
+  // -------------------------------------------------------------------------
+  // Additional edge case: evaluation_id is always a valid UUID
+  // -------------------------------------------------------------------------
+
+  it("returns a valid UUID as evaluation_id", () => {
+    const result = evaluate(OBS_ALL_PASSING, SEED_RULES);
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    expect(result.evaluation_id).toMatch(uuidRegex);
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling: evaluator throws -> status: "error"
+  // -------------------------------------------------------------------------
+
+  it('includes rule with status "error" when evaluator throws', () => {
+    // Create a rule with an unregistered type to trigger UnknownRuleTypeError
+    const badRule = {
+      id: "c0000000-0000-4000-c000-000000000001",
+      name: "Bad Rule",
+      description: "A rule with an unknown evaluator type",
+      type: "nonexistent_type" as any,
+      config: {},
+      mitigations: [],
+    };
+
+    const result = evaluate(OBS_ALL_PASSING, [badRule as any]);
+
+    const errorResult = result.vulnerabilities.find(
+      (v) => v.rule_name === "Bad Rule",
+    );
+    expect(errorResult).toBeDefined();
+    expect(errorResult!.status).toBe("error");
+    expect(errorResult!.details.explanation).toContain("Evaluation error");
+  });
+});

--- a/server/src/engine/engine.ts
+++ b/server/src/engine/engine.ts
@@ -1,0 +1,257 @@
+import { GLOBALLY_REQUIRED_FIELDS } from "../../../shared/schemas/observation.schema.js";
+import type {
+  EvaluationResult,
+  EvaluationSummary,
+  VulnerabilityResult,
+} from "../../../shared/types/evaluation.js";
+import type { Rule } from "../../../shared/types/rule.js";
+import { EvaluatorRegistry } from "./registry.js";
+import { SimpleThresholdEvaluator } from "./evaluators/simple-threshold.evaluator.js";
+
+// ---------------------------------------------------------------------------
+// UUID helper (avoids dependency on @types/node)
+// ---------------------------------------------------------------------------
+
+function generateUUID(): string {
+  // Use globalThis.crypto.randomUUID when available (Node 19+, modern browsers)
+  if (
+    typeof globalThis !== "undefined" &&
+    globalThis.crypto &&
+    typeof (globalThis.crypto as any).randomUUID === "function"
+  ) {
+    return (globalThis.crypto as any).randomUUID();
+  }
+  // Fallback: RFC-4122 v4 UUID via Math.random
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+import { ConditionalThresholdEvaluator } from "./evaluators/conditional-threshold.evaluator.js";
+import { ComputedWithModifiersEvaluator } from "./evaluators/computed-with-modifiers.evaluator.js";
+
+// ---------------------------------------------------------------------------
+// Pre-configured registry with all built-in evaluators
+// ---------------------------------------------------------------------------
+
+export const defaultRegistry = new EvaluatorRegistry();
+defaultRegistry.register("simple_threshold", new SimpleThresholdEvaluator());
+defaultRegistry.register(
+  "conditional_threshold",
+  new ConditionalThresholdEvaluator(),
+);
+defaultRegistry.register(
+  "computed_with_modifiers",
+  new ComputedWithModifiersEvaluator(),
+);
+
+// ---------------------------------------------------------------------------
+// Field extraction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip `[]` notation from a field name to get the top-level observation key.
+ * e.g. "vegetation[].type" -> "vegetation", "window_type" -> "window_type"
+ */
+function stripArrayNotation(field: string): string {
+  const bracketIndex = field.indexOf("[");
+  return bracketIndex >= 0 ? field.substring(0, bracketIndex) : field;
+}
+
+/**
+ * Extract all top-level observation fields that a rule's config references.
+ * Returns a deduplicated array of field names.
+ */
+function getReferencedFields(rule: Rule): string[] {
+  const fields = new Set<string>();
+
+  switch (rule.type) {
+    case "simple_threshold": {
+      const config = rule.config;
+      fields.add(stripArrayNotation(config.field));
+      break;
+    }
+    case "conditional_threshold": {
+      const config = rule.config;
+      for (const condition of config.conditions) {
+        fields.add(stripArrayNotation(condition.when.field));
+        fields.add(stripArrayNotation(condition.then.field));
+      }
+      fields.add(stripArrayNotation(config.default.field));
+      break;
+    }
+    case "computed_with_modifiers": {
+      const config = rule.config;
+      if (config.arrayField) {
+        fields.add(config.arrayField);
+      }
+      fields.add(stripArrayNotation(config.comparisonField));
+      for (const modifier of config.modifiers) {
+        fields.add(stripArrayNotation(modifier.field));
+      }
+      break;
+    }
+  }
+
+  return [...fields];
+}
+
+// ---------------------------------------------------------------------------
+// Main evaluate function
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate a set of observations against a list of rules.
+ *
+ * This is a pure function (aside from UUID generation for the evaluation ID).
+ * It validates globally required fields, dispatches each rule to its evaluator,
+ * collects results, and builds a summary.
+ */
+export function evaluate(
+  observations: Record<string, any>,
+  rules: Rule[],
+  registry: EvaluatorRegistry = defaultRegistry,
+): EvaluationResult {
+  const evaluationId = generateUUID();
+
+  // -------------------------------------------------------------------------
+  // Step 1: Validate globally required fields
+  // -------------------------------------------------------------------------
+
+  const missingGlobal: string[] = [];
+  for (const field of GLOBALLY_REQUIRED_FIELDS) {
+    if (observations[field] === undefined || observations[field] === null) {
+      missingGlobal.push(field);
+    }
+  }
+
+  if (missingGlobal.length > 0) {
+    return {
+      evaluation_id: evaluationId,
+      release: { id: "", name: "" },
+      auto_declined: false,
+      vulnerabilities: [],
+      skipped_rules: [],
+      summary: {
+        total_vulnerabilities: 0,
+        auto_decline_vulnerabilities: 0,
+        mitigatable: 0,
+        bridge_mitigations_available: 0,
+        bridge_mitigation_limit: 3,
+      },
+      validation_error: {
+        message: `Missing globally required fields: ${missingGlobal.join(", ")}`,
+        missingFields: missingGlobal,
+      },
+    } as EvaluationResult & { validation_error: any };
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2: Evaluate each rule
+  // -------------------------------------------------------------------------
+
+  const vulnerabilities: VulnerabilityResult[] = [];
+  const skippedRules: EvaluationResult["skipped_rules"] = [];
+
+  for (const rule of rules) {
+    // 2a: Check if rule-referenced fields are present
+    const referencedFields = getReferencedFields(rule);
+    const missing = referencedFields.filter(
+      (f) => observations[f] === undefined || observations[f] === null,
+    );
+
+    if (missing.length > 0) {
+      // 2b: Skip rule with warning
+      skippedRules.push({
+        rule_id: rule.id,
+        rule_name: rule.name,
+        reason: `Missing required observation fields: ${missing.join(", ")}`,
+        missingFields: missing,
+      });
+      continue;
+    }
+
+    // 2c: Dispatch to evaluator
+    try {
+      const { result } = registry.evaluate(rule, observations);
+
+      const vulnerability: VulnerabilityResult = {
+        rule_id: rule.id,
+        rule_name: rule.name,
+        description: rule.description,
+        triggered: result.triggered,
+        details: result.details,
+        mitigations: rule.mitigations,
+        status: "evaluated",
+      };
+
+      // 2d: Only add triggered rules to vulnerabilities
+      if (result.triggered) {
+        vulnerabilities.push(vulnerability);
+      }
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      vulnerabilities.push({
+        rule_id: rule.id,
+        rule_name: rule.name,
+        description: rule.description,
+        triggered: false,
+        details: {
+          observedValues: {},
+          requiredValues: {},
+          explanation: `Evaluation error: ${errorMessage}`,
+        },
+        mitigations: [],
+        status: "error",
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 3: Check auto-decline
+  // -------------------------------------------------------------------------
+
+  const autoDeclineVulnerabilities = vulnerabilities.filter(
+    (v) => v.triggered && v.mitigations.length === 0,
+  );
+  const autoDeclined = autoDeclineVulnerabilities.length > 0;
+
+  // -------------------------------------------------------------------------
+  // Step 4: Build summary
+  // -------------------------------------------------------------------------
+
+  const triggeredVulnerabilities = vulnerabilities.filter((v) => v.triggered);
+  const mitigatableVulnerabilities = triggeredVulnerabilities.filter(
+    (v) => v.mitigations.length > 0,
+  );
+  const bridgeMitigationsAvailable = new Set(
+    triggeredVulnerabilities.flatMap((v) =>
+      v.mitigations
+        .filter((m) => m.category === "bridge")
+        .map((m) => m.id),
+    ),
+  ).size;
+
+  const summary: EvaluationSummary = {
+    total_vulnerabilities: triggeredVulnerabilities.length,
+    auto_decline_vulnerabilities: autoDeclineVulnerabilities.length,
+    mitigatable: mitigatableVulnerabilities.length,
+    bridge_mitigations_available: bridgeMitigationsAvailable,
+    bridge_mitigation_limit: 3,
+  };
+
+  // -------------------------------------------------------------------------
+  // Step 5: Return EvaluationResult
+  // -------------------------------------------------------------------------
+
+  return {
+    evaluation_id: evaluationId,
+    release: { id: "", name: "" },
+    auto_declined: autoDeclined,
+    vulnerabilities,
+    skipped_rules: skippedRules,
+    summary,
+  };
+}

--- a/server/src/engine/index.ts
+++ b/server/src/engine/index.ts
@@ -1,0 +1,4 @@
+export { evaluate, defaultRegistry } from "./engine.js";
+export { EvaluatorRegistry } from "./registry.js";
+export { UnknownRuleTypeError } from "./errors.js";
+export type { Evaluator } from "./evaluator.interface.js";


### PR DESCRIPTION
## Summary
- `evaluate(observations, rules[])` pure function — the core of the engine
- Pipeline: validate required fields → check field presence per rule (skip with warning) → dispatch to evaluator → collect results → check auto-decline → build summary
- Pre-configured `defaultRegistry` with all 3 evaluators registered
- Barrel export via `index.ts`
- 19 integration tests using all 4 seed rules and 5 seed observation sets

## Test Results
64/64 tests pass across the entire server (19 new engine tests + 45 existing).
TypeScript compiles clean.

## Key Scenarios Tested
- All passing, single failure, multiple failures, auto-decline
- Missing globally required field → validation error
- Missing rule-referenced field → rule skipped with warning
- Determinism: identical input → identical output
- Empty rules array
- Performance: 4 rules in < 10ms

## FRs/NFRs
FR-2.1, FR-2.2, FR-2.3, FR-2.7, FR-9.1, FR-9.2, FR-9.3, FR-1.3, FR-1.4, NFR-1, NFR-7

Closes #13