### PR TITLE
Iteration 3.2: Repository layer

### DIFF
--- a/server/src/db/errors.ts
+++ b/server/src/db/errors.ts
@@ -1,0 +1,11 @@
+/**
+ * Thrown when an optimistic-locking version conflict is detected.
+ * The caller attempted to update a row whose version has already advanced
+ * past the expected value.
+ */
+export class ConflictError extends Error {
+  constructor(message = 'Version conflict: the record was modified by another request') {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}

--- a/server/src/db/repositories/audit-log.repository.ts
+++ b/server/src/db/repositories/audit-log.repository.ts
@@ -1,0 +1,33 @@
+import { PrismaClient, AuditLog } from '@prisma/client';
+import prisma from '../client.js';
+
+export class AuditLogRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async append(
+    action: string,
+    entityType: string,
+    entityId: string | null,
+    userId: string,
+    details?: unknown,
+  ): Promise<AuditLog> {
+    return this.db.auditLog.create({
+      data: {
+        action,
+        entityType,
+        entityId: entityId ?? undefined,
+        userId,
+        details: details !== undefined ? (details as any) : undefined,
+      },
+    });
+  }
+
+  async list(limit = 100): Promise<AuditLog[]> {
+    return this.db.auditLog.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+  }
+}
+
+export const auditLogRepository = new AuditLogRepository(prisma);

--- a/server/src/db/repositories/evaluation.repository.ts
+++ b/server/src/db/repositories/evaluation.repository.ts
@@ -1,0 +1,70 @@
+import { PrismaClient, Evaluation, EvaluationMitigation } from '@prisma/client';
+import prisma from '../client.js';
+
+export interface CreateEvaluationData {
+  propertyId: string;
+  releaseId: string;
+  observations: unknown;
+  result: unknown;
+  isAutoDeclined: boolean;
+  createdById: string;
+}
+
+export interface MitigationSelection {
+  ruleId: string;
+  mitigationId: string;
+  category: string;
+}
+
+export type EvaluationWithMitigations = Evaluation & {
+  mitigations: EvaluationMitigation[];
+};
+
+export class EvaluationRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async save(data: CreateEvaluationData): Promise<Evaluation> {
+    return this.db.evaluation.create({
+      data: {
+        propertyId: data.propertyId,
+        releaseId: data.releaseId,
+        observations: data.observations as any,
+        result: data.result as any,
+        isAutoDeclined: data.isAutoDeclined,
+        createdById: data.createdById,
+      },
+    });
+  }
+
+  async saveMitigations(
+    evaluationId: string,
+    selections: MitigationSelection[],
+  ): Promise<void> {
+    if (selections.length === 0) return;
+
+    await this.db.evaluationMitigation.createMany({
+      data: selections.map((s) => ({
+        evaluationId,
+        ruleId: s.ruleId,
+        mitigationId: s.mitigationId,
+        category: s.category,
+      })),
+    });
+  }
+
+  async findById(id: string): Promise<EvaluationWithMitigations | null> {
+    return this.db.evaluation.findUnique({
+      where: { id },
+      include: { mitigations: true },
+    });
+  }
+
+  async listByProperty(propertyId: string): Promise<Evaluation[]> {
+    return this.db.evaluation.findMany({
+      where: { propertyId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}
+
+export const evaluationRepository = new EvaluationRepository(prisma);

--- a/server/src/db/repositories/index.ts
+++ b/server/src/db/repositories/index.ts
@@ -1,0 +1,15 @@
+export { UserRepository, userRepository } from './user.repository.js';
+export { RuleRepository, ruleRepository } from './rule.repository.js';
+export type { CreateRuleData, UpdateRuleData } from './rule.repository.js';
+export { ReleaseRepository, releaseRepository } from './release.repository.js';
+export type { ReleaseWithRules } from './release.repository.js';
+export { EvaluationRepository, evaluationRepository } from './evaluation.repository.js';
+export type {
+  CreateEvaluationData,
+  MitigationSelection,
+  EvaluationWithMitigations,
+} from './evaluation.repository.js';
+export { PolicyLockRepository, policyLockRepository } from './policy-lock.repository.js';
+export { SettingsRepository, settingsRepository } from './settings.repository.js';
+export { AuditLogRepository, auditLogRepository } from './audit-log.repository.js';
+export { ConflictError } from '../errors.js';

--- a/server/src/db/repositories/policy-lock.repository.ts
+++ b/server/src/db/repositories/policy-lock.repository.ts
@@ -1,0 +1,22 @@
+import { PrismaClient, PolicyLock } from '@prisma/client';
+import prisma from '../client.js';
+
+export class PolicyLockRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async create(
+    propertyId: string,
+    releaseId: string,
+    lockedById: string,
+  ): Promise<PolicyLock> {
+    return this.db.policyLock.create({
+      data: { propertyId, releaseId, lockedById },
+    });
+  }
+
+  async findByPropertyId(propertyId: string): Promise<PolicyLock | null> {
+    return this.db.policyLock.findUnique({ where: { propertyId } });
+  }
+}
+
+export const policyLockRepository = new PolicyLockRepository(prisma);

--- a/server/src/db/repositories/release.repository.ts
+++ b/server/src/db/repositories/release.repository.ts
@@ -1,0 +1,91 @@
+import { PrismaClient, Release, ReleaseRule } from '@prisma/client';
+import prisma from '../client.js';
+
+export type ReleaseWithRules = Release & { releaseRules: ReleaseRule[] };
+
+export class ReleaseRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  /**
+   * Publish a new release by atomically snapshotting every current draft rule
+   * into release_rules rows and creating the release record.
+   */
+  async publish(name: string, publishedById: string): Promise<ReleaseWithRules> {
+    return this.db.$transaction(async (tx) => {
+      // Load all current draft rules
+      const draftRules = await tx.rule.findMany();
+
+      // Create the release
+      const release = await tx.release.create({
+        data: {
+          name,
+          publishedBy: publishedById,
+          isActive: false,
+        },
+      });
+
+      // Snapshot each draft rule into release_rules
+      const releaseRules: ReleaseRule[] = [];
+      for (const rule of draftRules) {
+        const rr = await tx.releaseRule.create({
+          data: {
+            releaseId: release.id,
+            ruleId: rule.id,
+            ruleSnapshot: {
+              id: rule.id,
+              name: rule.name,
+              description: rule.description,
+              type: rule.type,
+              config: rule.config,
+              mitigations: rule.mitigations,
+              version: rule.version,
+            },
+          },
+        });
+        releaseRules.push(rr);
+      }
+
+      return { ...release, releaseRules };
+    });
+  }
+
+  /**
+   * Activate a release. Exactly one release may be active at a time:
+   * deactivate all existing releases, then activate the target.
+   */
+  async activate(id: string): Promise<Release> {
+    return this.db.$transaction(async (tx) => {
+      // Deactivate all releases
+      await tx.release.updateMany({
+        data: { isActive: false },
+      });
+
+      // Activate the target release
+      return tx.release.update({
+        where: { id },
+        data: { isActive: true },
+      });
+    });
+  }
+
+  async findActive(): Promise<Release | null> {
+    return this.db.release.findFirst({ where: { isActive: true } });
+  }
+
+  async findById(id: string): Promise<Release | null> {
+    return this.db.release.findUnique({ where: { id } });
+  }
+
+  async findByIdWithRules(id: string): Promise<ReleaseWithRules | null> {
+    return this.db.release.findUnique({
+      where: { id },
+      include: { releaseRules: true },
+    });
+  }
+
+  async list(): Promise<Release[]> {
+    return this.db.release.findMany({ orderBy: { publishedAt: 'desc' } });
+  }
+}
+
+export const releaseRepository = new ReleaseRepository(prisma);

--- a/server/src/db/repositories/rule.repository.ts
+++ b/server/src/db/repositories/rule.repository.ts
@@ -1,0 +1,88 @@
+import { PrismaClient, Rule } from '@prisma/client';
+import prisma from '../client.js';
+import { ConflictError } from '../errors.js';
+
+export interface CreateRuleData {
+  name: string;
+  description?: string;
+  type: string;
+  config: unknown;
+  mitigations: unknown;
+  createdById: string;
+}
+
+export interface UpdateRuleData {
+  name?: string;
+  description?: string;
+  type?: string;
+  config?: unknown;
+  mitigations?: unknown;
+}
+
+export class RuleRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async create(data: CreateRuleData): Promise<Rule> {
+    return this.db.rule.create({
+      data: {
+        name: data.name,
+        description: data.description,
+        type: data.type,
+        config: data.config as any,
+        mitigations: data.mitigations as any,
+        createdById: data.createdById,
+        version: 1,
+      },
+    });
+  }
+
+  async findById(id: string): Promise<Rule | null> {
+    return this.db.rule.findUnique({ where: { id } });
+  }
+
+  async list(): Promise<Rule[]> {
+    return this.db.rule.findMany({ orderBy: { updatedAt: 'desc' } });
+  }
+
+  /**
+   * Update a rule using optimistic locking.
+   * The WHERE clause includes both `id` AND `version` so that a concurrent
+   * modification (which would have incremented the version) causes zero rows
+   * to match, and a ConflictError is thrown.
+   */
+  async update(id: string, data: UpdateRuleData, expectedVersion: number): Promise<Rule> {
+    const [updated] = await this.db.$queryRawUnsafe<Rule[]>(
+      `UPDATE rules
+       SET name        = COALESCE($1, name),
+           description = COALESCE($2, description),
+           type        = COALESCE($3, type),
+           config      = COALESCE($4::jsonb, config),
+           mitigations = COALESCE($5::jsonb, mitigations),
+           version     = version + 1,
+           updated_at  = NOW()
+       WHERE id = $6::uuid AND version = $7
+       RETURNING *`,
+      data.name ?? null,
+      data.description ?? null,
+      data.type ?? null,
+      data.config !== undefined ? JSON.stringify(data.config) : null,
+      data.mitigations !== undefined ? JSON.stringify(data.mitigations) : null,
+      id,
+      expectedVersion,
+    );
+
+    if (!updated) {
+      throw new ConflictError(
+        `Rule ${id} version conflict: expected version ${expectedVersion}`,
+      );
+    }
+
+    return updated;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.rule.delete({ where: { id } });
+  }
+}
+
+export const ruleRepository = new RuleRepository(prisma);

--- a/server/src/db/repositories/settings.repository.ts
+++ b/server/src/db/repositories/settings.repository.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+import prisma from '../client.js';
+
+export class SettingsRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async get(key: string): Promise<unknown> {
+    const setting = await this.db.setting.findUnique({ where: { key } });
+    return setting?.value ?? null;
+  }
+
+  async getAll(): Promise<Record<string, unknown>> {
+    const settings = await this.db.setting.findMany();
+    const result: Record<string, unknown> = {};
+    for (const s of settings) {
+      result[s.key] = s.value;
+    }
+    return result;
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    await this.db.setting.upsert({
+      where: { key },
+      update: { value: value as any },
+      create: { key, value: value as any },
+    });
+  }
+}
+
+export const settingsRepository = new SettingsRepository(prisma);

--- a/server/src/db/repositories/user.repository.ts
+++ b/server/src/db/repositories/user.repository.ts
@@ -1,0 +1,26 @@
+import { PrismaClient, User } from '@prisma/client';
+import prisma from '../client.js';
+
+export class UserRepository {
+  constructor(private readonly db: PrismaClient) {}
+
+  async create(email: string, passwordHash: string, role: string): Promise<User> {
+    return this.db.user.create({
+      data: { email, passwordHash, role },
+    });
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return this.db.user.findUnique({ where: { email } });
+  }
+
+  async findById(id: string): Promise<User | null> {
+    return this.db.user.findUnique({ where: { id } });
+  }
+
+  async list(): Promise<User[]> {
+    return this.db.user.findMany({ orderBy: { createdAt: 'desc' } });
+  }
+}
+
+export const userRepository = new UserRepository(prisma);


### PR DESCRIPTION
## Summary
- 7 repository classes with dependency injection (PrismaClient via constructor)
- Rule repo: CRUD with optimistic locking (version check, ConflictError on mismatch)
- Release repo: transactional publish (snapshot all drafts) and activate (exactly-one-active)
- Evaluation repo: save with mitigations, list by property
- Policy lock, settings (upsert), audit log (append-only)
- Barrel export + pre-wired singleton instances

## Key Design
- DI pattern: constructor takes PrismaClient for testability, default export uses singleton
- Optimistic locking via raw SQL `WHERE id AND version`
- `$transaction()` for atomic publish and activate

Closes #21