### PR TITLE
Iteration 4.2: Auth routes (login, register)

### DIFF
--- a/server/src/__tests__/api/auth.test.ts
+++ b/server/src/__tests__/api/auth.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Integration tests for auth routes (POST /api/auth/login, POST /api/auth/register).
+ *
+ * Uses a dedicated test database and seeds users via Prisma directly.
+ * DATABASE_URL and JWT_SECRET are set in vitest.config.ts so the singleton
+ * PrismaClient used by the app connects to the test DB.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import { hashSync } from 'bcryptjs';
+import { PrismaClient } from '@prisma/client';
+import app from '../../app.js';
+import { signToken } from '../../lib/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Test PrismaClient (same URL as the one the app will use via env var)
+// ---------------------------------------------------------------------------
+
+const testDb = new PrismaClient({
+  datasources: {
+    db: {
+      url: 'postgresql://managpan@localhost:5432/mitigation_rules_engine_test',
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_PASSWORD = 'Test1234!';
+const PASSWORD_HASH = hashSync(TEST_PASSWORD, 4);
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await testDb.$connect();
+});
+
+beforeEach(async () => {
+  // Use TRUNCATE CASCADE to avoid FK ordering issues when running in
+  // parallel with other test files that share the same test database.
+  await testDb.$executeRawUnsafe(
+    `TRUNCATE TABLE users, rules, releases, release_rules, evaluations,
+     evaluation_mitigations, policy_locks, audit_log, settings
+     CASCADE`,
+  );
+});
+
+afterAll(async () => {
+  await testDb.$disconnect();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedUser(email: string, role = 'admin') {
+  return testDb.user.create({
+    data: { email, passwordHash: PASSWORD_HASH, role },
+  });
+}
+
+function adminToken(user: { id: string; email: string; role: string }) {
+  return signToken({ userId: user.id, email: user.email, role: user.role });
+}
+
+// ===========================================================================
+// POST /api/auth/login
+// ===========================================================================
+
+describe('POST /api/auth/login', () => {
+  it('1 - returns token and user for correct credentials', async () => {
+    await seedUser('alice@example.com', 'admin');
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'alice@example.com', password: TEST_PASSWORD });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('token');
+    expect(res.body.data.user).toMatchObject({
+      email: 'alice@example.com',
+      role: 'admin',
+    });
+    // user should NOT expose passwordHash
+    expect(res.body.data.user).not.toHaveProperty('passwordHash');
+  });
+
+  it('2 - returns 401 for wrong password', async () => {
+    await seedUser('bob@example.com', 'underwriter');
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'bob@example.com', password: 'WrongPassword99!' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('3 - returns 401 for unknown email', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'nobody@example.com', password: 'Whatever1!' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe('UNAUTHORIZED');
+  });
+
+  it('4 - returns 400 for invalid body (missing email)', async () => {
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ password: 'Test1234!' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+// ===========================================================================
+// POST /api/auth/register
+// ===========================================================================
+
+describe('POST /api/auth/register', () => {
+  it('5 - admin creates a new user and gets 201', async () => {
+    const admin = await seedUser('admin@example.com', 'admin');
+    const token = adminToken(admin);
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        email: 'newuser@example.com',
+        password: 'Secure1234!',
+        role: 'underwriter',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      email: 'newuser@example.com',
+      role: 'underwriter',
+    });
+    expect(res.body.data).toHaveProperty('id');
+    expect(res.body.data).not.toHaveProperty('passwordHash');
+  });
+
+  it('6 - non-admin gets 403', async () => {
+    const viewer = await seedUser('viewer@example.com', 'underwriter');
+    const token = adminToken(viewer);
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        email: 'another@example.com',
+        password: 'Secure1234!',
+        role: 'underwriter',
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('7 - duplicate email returns 409', async () => {
+    const admin = await seedUser('admin2@example.com', 'admin');
+    const token = adminToken(admin);
+
+    // First registration should succeed
+    await request(app)
+      .post('/api/auth/register')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        email: 'duplicate@example.com',
+        password: 'Secure1234!',
+        role: 'underwriter',
+      });
+
+    // Second registration with same email should fail
+    const res = await request(app)
+      .post('/api/auth/register')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        email: 'duplicate@example.com',
+        password: 'Secure1234!',
+        role: 'applied_science',
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('CONFLICT');
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import cors from 'cors';
+import { errorHandler } from './middleware/error-handler.middleware.js';
+import authRoutes from './routes/auth.routes.js';
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/auth', authRoutes);
+
+app.use(errorHandler);
+
+export default app;

--- a/server/src/routes/auth.routes.ts
+++ b/server/src/routes/auth.routes.ts
@@ -1,0 +1,53 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { validateBody } from '../middleware/validate.middleware.js';
+import { authMiddleware } from '../middleware/auth.middleware.js';
+import { requireRole } from '../middleware/role.middleware.js';
+import { LoginRequestSchema, CreateUserRequestSchema } from '@shared/schemas/user.schema.js';
+import * as authService from '../services/auth.service.js';
+import type { ApiResponse, LoginResponse } from '@shared/types/api.js';
+import type { User } from '@shared/types/user.js';
+
+const router = Router();
+
+/**
+ * POST /login
+ * Public endpoint. Validates body against LoginRequestSchema,
+ * authenticates with email + password, returns JWT + user.
+ */
+router.post(
+  '/login',
+  validateBody(LoginRequestSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { email, password } = req.body;
+      const result = await authService.login(email, password);
+      const body: ApiResponse<LoginResponse> = { data: result };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * POST /register
+ * Admin-only endpoint. Creates a new user account.
+ */
+router.post(
+  '/register',
+  authMiddleware,
+  requireRole('admin'),
+  validateBody(CreateUserRequestSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { email, password, role } = req.body;
+      const user = await authService.register(email, password, role);
+      const body: ApiResponse<User> = { data: user };
+      res.status(201).json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/server/src/services/auth.service.ts
+++ b/server/src/services/auth.service.ts
@@ -1,0 +1,68 @@
+import bcrypt from 'bcryptjs';
+import { userRepository } from '../db/repositories/user.repository.js';
+import { signToken } from '../lib/jwt.js';
+import { UnauthorizedError } from '../lib/errors.js';
+import type { User as PrismaUser } from '@prisma/client';
+import type { User } from '@shared/types/user.js';
+
+const BCRYPT_ROUNDS = 12;
+
+/**
+ * Strip the passwordHash field from a Prisma User and return a safe User DTO.
+ */
+function toUserDTO(user: PrismaUser): User {
+  return { id: user.id, email: user.email, role: user.role as User['role'] };
+}
+
+/**
+ * Authenticate a user by email and password.
+ * Returns a signed JWT and user DTO, or throws UnauthorizedError.
+ */
+export async function login(
+  email: string,
+  password: string,
+): Promise<{ token: string; user: User }> {
+  const user = await userRepository.findByEmail(email);
+
+  if (!user) {
+    throw new UnauthorizedError('Invalid email or password');
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+
+  if (!valid) {
+    throw new UnauthorizedError('Invalid email or password');
+  }
+
+  const token = signToken({
+    userId: user.id,
+    email: user.email,
+    role: user.role,
+  });
+
+  return { token, user: toUserDTO(user) };
+}
+
+/**
+ * Register a new user. Hashes the password and persists via repository.
+ * Throws AppError(409) if the email already exists.
+ */
+export async function register(
+  email: string,
+  password: string,
+  role: string,
+): Promise<User> {
+  const passwordHash = await bcrypt.hash(password, BCRYPT_ROUNDS);
+
+  try {
+    const user = await userRepository.create(email, passwordHash, role);
+    return toUserDTO(user);
+  } catch (err: any) {
+    // Prisma unique constraint violation code
+    if (err?.code === 'P2002') {
+      const { AppError } = await import('../lib/errors.js');
+      throw new AppError(409, 'CONFLICT', 'A user with this email already exists');
+    }
+    throw err;
+  }
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
+  test: {
+    globals: false,
+    fileParallelism: false,
+    env: {
+      DATABASE_URL:
+        'postgresql://managpan@localhost:5432/mitigation_rules_engine_test',
+      JWT_SECRET: 'test-jwt-secret-do-not-use',
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Auth service: login (bcrypt compare + JWT sign), register (hash + create, 409 on duplicate)
- `POST /api/auth/login` — returns token + user (no password hash leaked)
- `POST /api/auth/register` — admin-only, validates via Zod
- Express app with cors, JSON parsing, error handler
- Vitest config with path aliases and test DB env vars
- 7 integration tests with supertest

## Test Results
94/94 tests pass (7 new auth + 87 existing).

Closes #29