### PR TITLE
Iteration 4.4: Rule CRUD and Release routes

### DIFF
--- a/server/src/__tests__/api/rules.test.ts
+++ b/server/src/__tests__/api/rules.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Integration tests for rule CRUD routes and release routes.
+ *
+ * Uses a dedicated test database seeded via Prisma directly.
+ * DATABASE_URL and JWT_SECRET are set in vitest.config.ts.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import { hashSync } from 'bcryptjs';
+import { PrismaClient } from '@prisma/client';
+import app from '../../app.js';
+import { signToken } from '../../lib/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Test PrismaClient
+// ---------------------------------------------------------------------------
+
+const testDb = new PrismaClient({
+  datasources: {
+    db: {
+      url: 'postgresql://managpan@localhost:5432/mitigation_rules_engine_test',
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_PASSWORD = 'Test1234!';
+const PASSWORD_HASH = hashSync(TEST_PASSWORD, 4);
+
+/** A valid simple_threshold rule body (no id — server generates it) */
+const VALID_RULE_BODY = {
+  name: 'Roof Age Check',
+  description: 'Flag properties with old roofs',
+  type: 'simple_threshold' as const,
+  config: {
+    field: 'roof_age',
+    operator: 'gte',
+    value: 20,
+  },
+  mitigations: [
+    {
+      id: '00000000-0000-4000-a000-000000000001',
+      name: 'Roof replacement',
+      description: 'Full roof replacement required',
+      category: 'full' as const,
+    },
+  ],
+};
+
+/** Invalid config (missing required field) */
+const INVALID_RULE_BODY = {
+  name: 'Bad Rule',
+  description: 'Missing config field',
+  type: 'simple_threshold' as const,
+  config: {
+    // field is missing
+    operator: 'gte',
+    value: 20,
+  },
+  mitigations: [],
+};
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await testDb.$connect();
+});
+
+beforeEach(async () => {
+  await testDb.$executeRawUnsafe(
+    `TRUNCATE TABLE users, rules, releases, release_rules, evaluations,
+     evaluation_mitigations, policy_locks, audit_log, settings
+     CASCADE`,
+  );
+});
+
+afterAll(async () => {
+  await testDb.$disconnect();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedUser(email: string, role = 'applied_science') {
+  return testDb.user.create({
+    data: { email, passwordHash: PASSWORD_HASH, role },
+  });
+}
+
+function tokenFor(user: { id: string; email: string; role: string }) {
+  return signToken({ userId: user.id, email: user.email, role: user.role });
+}
+
+async function createRuleViaApi(token: string, body = VALID_RULE_BODY) {
+  return request(app)
+    .post('/api/rules')
+    .set('Authorization', `Bearer ${token}`)
+    .send(body);
+}
+
+// ===========================================================================
+// Rule CRUD Routes
+// ===========================================================================
+
+describe('Rule CRUD — /api/rules', () => {
+  it('1 - POST /api/rules creates a rule (201)', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const res = await createRuleViaApi(token);
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      name: VALID_RULE_BODY.name,
+      type: VALID_RULE_BODY.type,
+    });
+    expect(res.body.data).toHaveProperty('id');
+    expect(res.body.data.version).toBe(1);
+  });
+
+  it('2 - GET /api/rules lists rules', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    await createRuleViaApi(token);
+    await createRuleViaApi(token, {
+      ...VALID_RULE_BODY,
+      name: 'Second Rule',
+    });
+
+    const res = await request(app)
+      .get('/api/rules')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  it('3 - GET /api/rules/:id returns rule detail', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const createRes = await createRuleViaApi(token);
+    const ruleId = createRes.body.data.id;
+
+    const res = await request(app)
+      .get(`/api/rules/${ruleId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.id).toBe(ruleId);
+    expect(res.body.data.name).toBe(VALID_RULE_BODY.name);
+  });
+
+  it('4 - PUT /api/rules/:id updates rule', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const createRes = await createRuleViaApi(token);
+    const ruleId = createRes.body.data.id;
+
+    const res = await request(app)
+      .put(`/api/rules/${ruleId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Updated Roof Check',
+        version: 1,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe('Updated Roof Check');
+    expect(res.body.data.version).toBe(2);
+  });
+
+  it('5 - PUT /api/rules/:id with wrong version returns 409', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const createRes = await createRuleViaApi(token);
+    const ruleId = createRes.body.data.id;
+
+    const res = await request(app)
+      .put(`/api/rules/${ruleId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Stale Update',
+        version: 99, // wrong version
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe('CONFLICT');
+  });
+
+  it('6 - DELETE /api/rules/:id removes rule (204)', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const createRes = await createRuleViaApi(token);
+    const ruleId = createRes.body.data.id;
+
+    const delRes = await request(app)
+      .delete(`/api/rules/${ruleId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(delRes.status).toBe(204);
+
+    // Verify it's gone
+    const getRes = await request(app)
+      .get(`/api/rules/${ruleId}`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(getRes.status).toBe(404);
+  });
+
+  it('7 - POST /api/rules with invalid config returns 400', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const res = await createRuleViaApi(token, INVALID_RULE_BODY as any);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('8 - POST /api/rules/:id/test returns evaluation without saving', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    const createRes = await createRuleViaApi(token);
+    const ruleId = createRes.body.data.id;
+
+    const res = await request(app)
+      .post(`/api/rules/${ruleId}/test`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        observations: {
+          property_id: 'PROP-001',
+          year_built: 1990,
+          roof_age: 25,
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('evaluation_id');
+    expect(res.body.data).toHaveProperty('vulnerabilities');
+    // Rule should trigger since roof_age (25) >= 20
+    expect(res.body.data.vulnerabilities.length).toBeGreaterThanOrEqual(1);
+    expect(res.body.data.vulnerabilities[0].triggered).toBe(true);
+  });
+});
+
+// ===========================================================================
+// Release Routes
+// ===========================================================================
+
+describe('Release Routes — /api/releases', () => {
+  it('9 - POST /api/releases publishes release (201)', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    // First create a rule so the release has something to snapshot
+    await createRuleViaApi(token);
+
+    const res = await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'v1.0' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      name: 'v1.0',
+      isActive: false,
+    });
+    expect(res.body.data.releaseRules).toHaveLength(1);
+  });
+
+  it('10 - PUT /api/releases/:id/activate activates release', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    await createRuleViaApi(token);
+
+    const publishRes = await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'v1.0' });
+
+    const releaseId = publishRes.body.data.id;
+
+    const res = await request(app)
+      .put(`/api/releases/${releaseId}/activate`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.isActive).toBe(true);
+  });
+
+  it('11 - GET /api/releases/active/rules returns rules from active release', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    // Create a rule, publish, and activate
+    await createRuleViaApi(token);
+
+    const publishRes = await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'v1.0' });
+
+    const releaseId = publishRes.body.data.id;
+
+    await request(app)
+      .put(`/api/releases/${releaseId}/activate`)
+      .set('Authorization', `Bearer ${token}`);
+
+    const res = await request(app)
+      .get('/api/releases/active/rules')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toHaveProperty('name', VALID_RULE_BODY.name);
+  });
+
+  it('12 - Non-applied-science user gets 403 on rule routes', async () => {
+    const underwriter = await seedUser('uw@example.com', 'underwriter');
+    const token = tokenFor(underwriter);
+
+    const res = await request(app)
+      .get('/api/rules')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('13 - Underwriter CAN access GET /api/releases/active/rules', async () => {
+    const scientist = await seedUser('scientist@example.com', 'applied_science');
+    const sciToken = tokenFor(scientist);
+
+    // Create rule, publish, activate as scientist
+    await createRuleViaApi(sciToken);
+
+    const publishRes = await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${sciToken}`)
+      .send({ name: 'v1.0' });
+
+    await request(app)
+      .put(`/api/releases/${publishRes.body.data.id}/activate`)
+      .set('Authorization', `Bearer ${sciToken}`);
+
+    // Now an underwriter should be able to read active rules
+    const underwriter = await seedUser('uw@example.com', 'underwriter');
+    const uwToken = tokenFor(underwriter);
+
+    const res = await request(app)
+      .get('/api/releases/active/rules')
+      .set('Authorization', `Bearer ${uwToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+
+  it('14 - GET /api/releases lists all releases', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    await createRuleViaApi(token);
+
+    await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'v1.0' });
+
+    await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'v2.0' });
+
+    const res = await request(app)
+      .get('/api/releases')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(2);
+  });
+
+  it('15 - GET /api/releases/:id/rules returns rules for a release', async () => {
+    const user = await seedUser('scientist@example.com');
+    const token = tokenFor(user);
+
+    await createRuleViaApi(token);
+
+    const publishRes = await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'v1.0' });
+
+    const releaseId = publishRes.body.data.id;
+
+    const res = await request(app)
+      .get(`/api/releases/${releaseId}/rules`)
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(1);
+  });
+});

--- a/server/src/routes/release.routes.ts
+++ b/server/src/routes/release.routes.ts
@@ -1,0 +1,101 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { authMiddleware, requireRole, validateBody } from '../middleware/index.js';
+import { CreateReleaseRequestSchema } from '@shared/schemas/release.schema.js';
+import * as releaseService from '../services/release.service.js';
+import type { ApiResponse } from '@shared/types/api.js';
+
+const router = Router();
+
+/**
+ * GET /active/rules — get rules from the currently active release.
+ * Accessible by both applied_science AND underwriter roles.
+ * Must be defined BEFORE the /:id routes to avoid matching "active" as an id.
+ */
+router.get(
+  '/active/rules',
+  authMiddleware,
+  requireRole('applied_science', 'underwriter'),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const rules = await releaseService.getActiveRules();
+      const body: ApiResponse<typeof rules> = { data: rules };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+// All other release routes require auth + applied_science role
+router.use(authMiddleware, requireRole('applied_science'));
+
+/**
+ * GET / — list all releases
+ */
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const releases = await releaseService.list();
+    const body: ApiResponse<typeof releases> = { data: releases };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST / — publish a new release (snapshots all current draft rules)
+ */
+router.post(
+  '/',
+  validateBody(CreateReleaseRequestSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const release = await releaseService.publish(req.body.name, req.user!.id);
+      const body: ApiResponse<typeof release> = { data: release };
+      res.status(201).json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * GET /:id — get release by id
+ */
+router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const release = await releaseService.findById(req.params.id);
+    const body: ApiResponse<typeof release> = { data: release };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /:id/rules — get rules for a specific release
+ */
+router.get('/:id/rules', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const rules = await releaseService.getRulesForRelease(req.params.id);
+    const body: ApiResponse<typeof rules> = { data: rules };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * PUT /:id/activate — activate a release
+ */
+router.put('/:id/activate', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const release = await releaseService.activate(req.params.id, req.user!.id);
+    const body: ApiResponse<typeof release> = { data: release };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/server/src/routes/rule.routes.ts
+++ b/server/src/routes/rule.routes.ts
@@ -1,0 +1,154 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { authMiddleware, requireRole, validateBody } from '../middleware/index.js';
+import * as ruleService from '../services/rule.service.js';
+import { z } from 'zod';
+import {
+  RuleTypeSchema,
+  SimpleConfigSchema,
+  ConditionalConfigSchema,
+  ComputedConfigSchema,
+  MitigationSchema,
+} from '@shared/schemas/rule.schema.js';
+import type { ApiResponse } from '@shared/types/api.js';
+
+// ---------------------------------------------------------------------------
+// Request body schemas (server-side, no id — server generates it)
+// ---------------------------------------------------------------------------
+
+const CreateRuleBodySchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('simple_threshold'),
+    name: z.string().min(1),
+    description: z.string().min(1),
+    config: SimpleConfigSchema,
+    mitigations: z.array(MitigationSchema),
+  }),
+  z.object({
+    type: z.literal('conditional_threshold'),
+    name: z.string().min(1),
+    description: z.string().min(1),
+    config: ConditionalConfigSchema,
+    mitigations: z.array(MitigationSchema),
+  }),
+  z.object({
+    type: z.literal('computed_with_modifiers'),
+    name: z.string().min(1),
+    description: z.string().min(1),
+    config: ComputedConfigSchema,
+    mitigations: z.array(MitigationSchema),
+  }),
+]);
+
+const UpdateRuleBodySchema = z.object({
+  name: z.string().min(1).optional(),
+  description: z.string().min(1).optional(),
+  type: RuleTypeSchema.optional(),
+  config: z.any().optional(),
+  mitigations: z.array(MitigationSchema).optional(),
+  version: z.number().int().positive(),
+});
+
+const TestRuleBodySchema = z.object({
+  observations: z.record(z.string(), z.any()),
+});
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+const router = Router();
+
+// All rule routes require auth + applied_science role
+router.use(authMiddleware, requireRole('applied_science'));
+
+/**
+ * GET / — list all draft rules
+ */
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const rules = await ruleService.list();
+    const body: ApiResponse<typeof rules> = { data: rules };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST / — create a new rule
+ */
+router.post(
+  '/',
+  validateBody(CreateRuleBodySchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const rule = await ruleService.create(req.body, req.user!.id);
+      const body: ApiResponse<typeof rule> = { data: rule };
+      res.status(201).json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * GET /:id — get rule by id
+ */
+router.get('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const rule = await ruleService.findById(req.params.id);
+    const body: ApiResponse<typeof rule> = { data: rule };
+    res.json(body);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * PUT /:id — update a rule (version in body for optimistic locking)
+ */
+router.put(
+  '/:id',
+  validateBody(UpdateRuleBodySchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { version, ...data } = req.body;
+      const rule = await ruleService.update(req.params.id, data, version);
+      const body: ApiResponse<typeof rule> = { data: rule };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * DELETE /:id — delete a rule
+ */
+router.delete('/:id', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    await ruleService.remove(req.params.id);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /:id/test — test a rule against observations (no DB save)
+ */
+router.post(
+  '/:id/test',
+  validateBody(TestRuleBodySchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const result = await ruleService.test(req.params.id, req.body.observations);
+      const body: ApiResponse<typeof result> = { data: result };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/server/src/services/release.service.ts
+++ b/server/src/services/release.service.ts
@@ -1,0 +1,125 @@
+import { releaseRepository } from '../db/repositories/release.repository.js';
+import { ruleRepository } from '../db/repositories/rule.repository.js';
+import { auditLogRepository } from '../db/repositories/audit-log.repository.js';
+import { defaultRegistry } from '../engine/engine.js';
+import { NotFoundError, ValidationError } from '../lib/errors.js';
+import type { Rule } from '@shared/types/rule.js';
+
+/**
+ * Publish a new release by snapshotting all current draft rules.
+ * Validates every draft rule before publishing.
+ */
+export async function publish(name: string, userId: string) {
+  // Validate all draft rules before publishing
+  const draftRules = await ruleRepository.list();
+
+  if (draftRules.length === 0) {
+    throw new ValidationError('Cannot publish a release with no rules');
+  }
+
+  const allErrors: string[] = [];
+  for (const rule of draftRules) {
+    const evaluator = defaultRegistry.get(rule.type);
+    const { valid, errors } = evaluator.validate(rule.config);
+    if (!valid) {
+      allErrors.push(`Rule "${rule.name}" (${rule.id}): ${errors.join(', ')}`);
+    }
+  }
+
+  if (allErrors.length > 0) {
+    throw new ValidationError('Some rules have invalid configurations', allErrors);
+  }
+
+  const release = await releaseRepository.publish(name, userId);
+
+  await auditLogRepository.append(
+    'release.published',
+    'release',
+    release.id,
+    userId,
+    { name, ruleCount: release.releaseRules.length },
+  );
+
+  return release;
+}
+
+/**
+ * Activate a release. Only one release may be active at a time.
+ */
+export async function activate(id: string, userId: string) {
+  // Verify the release exists
+  const release = await releaseRepository.findById(id);
+  if (!release) {
+    throw new NotFoundError(`Release ${id} not found`);
+  }
+
+  const activated = await releaseRepository.activate(id);
+
+  await auditLogRepository.append(
+    'release.activated',
+    'release',
+    id,
+    userId,
+    { name: activated.name },
+  );
+
+  return activated;
+}
+
+/**
+ * Find a release by id or throw NotFoundError.
+ */
+export async function findById(id: string) {
+  const release = await releaseRepository.findById(id);
+  if (!release) {
+    throw new NotFoundError(`Release ${id} not found`);
+  }
+  return release;
+}
+
+/**
+ * Find a release by id with its rule snapshots, or throw NotFoundError.
+ */
+export async function findByIdWithRules(id: string) {
+  const release = await releaseRepository.findByIdWithRules(id);
+  if (!release) {
+    throw new NotFoundError(`Release ${id} not found`);
+  }
+  return release;
+}
+
+/**
+ * Get rules from the currently active release.
+ * Returns the rule snapshots from the active release.
+ */
+export async function getActiveRules() {
+  const active = await releaseRepository.findActive();
+  if (!active) {
+    return [];
+  }
+
+  const release = await releaseRepository.findByIdWithRules(active.id);
+  if (!release) {
+    return [];
+  }
+
+  return release.releaseRules.map((rr) => rr.ruleSnapshot);
+}
+
+/**
+ * Get rules for a specific release.
+ */
+export async function getRulesForRelease(id: string) {
+  const release = await releaseRepository.findByIdWithRules(id);
+  if (!release) {
+    throw new NotFoundError(`Release ${id} not found`);
+  }
+  return release.releaseRules.map((rr) => rr.ruleSnapshot);
+}
+
+/**
+ * List all releases.
+ */
+export async function list() {
+  return releaseRepository.list();
+}

--- a/server/src/services/rule.service.ts
+++ b/server/src/services/rule.service.ts
@@ -1,0 +1,110 @@
+import { ruleRepository } from '../db/repositories/rule.repository.js';
+import { defaultRegistry } from '../engine/engine.js';
+import { evaluate } from '../engine/engine.js';
+import { NotFoundError, ValidationError } from '../lib/errors.js';
+import type { Rule } from '@shared/types/rule.js';
+
+/**
+ * Create a new rule. Validates the config against the evaluator registry
+ * before persisting.
+ */
+export async function create(
+  data: { name: string; description: string; type: string; config: unknown; mitigations: unknown },
+  userId: string,
+) {
+  // Validate config against the evaluator for this rule type
+  validateConfig(data.type, data.config);
+
+  return ruleRepository.create({
+    name: data.name,
+    description: data.description,
+    type: data.type,
+    config: data.config,
+    mitigations: data.mitigations,
+    createdById: userId,
+  });
+}
+
+/**
+ * Update an existing rule with optimistic locking.
+ * If config or type changes, re-validates.
+ */
+export async function update(
+  id: string,
+  data: { name?: string; description?: string; type?: string; config?: unknown; mitigations?: unknown },
+  expectedVersion: number,
+) {
+  // If config is provided, validate it against the evaluator
+  if (data.config !== undefined) {
+    // If type is also being changed, use new type; otherwise load current rule to get type
+    let ruleType = data.type;
+    if (!ruleType) {
+      const existing = await ruleRepository.findById(id);
+      if (!existing) {
+        throw new NotFoundError(`Rule ${id} not found`);
+      }
+      ruleType = existing.type;
+    }
+    validateConfig(ruleType, data.config);
+  }
+
+  return ruleRepository.update(id, data, expectedVersion);
+}
+
+/**
+ * Delete a rule by id.
+ */
+export async function remove(id: string) {
+  return ruleRepository.delete(id);
+}
+
+/**
+ * Find a rule by id or throw NotFoundError.
+ */
+export async function findById(id: string) {
+  const rule = await ruleRepository.findById(id);
+  if (!rule) {
+    throw new NotFoundError(`Rule ${id} not found`);
+  }
+  return rule;
+}
+
+/**
+ * List all draft rules.
+ */
+export async function list() {
+  return ruleRepository.list();
+}
+
+/**
+ * Test a single rule against provided observations without persisting.
+ * Loads the rule from DB, runs the engine's evaluate() with just that rule,
+ * and returns the result.
+ */
+export async function test(ruleId: string, observations: Record<string, any>) {
+  const dbRule = await findById(ruleId);
+
+  // Convert DB rule to engine Rule shape
+  const rule: Rule = {
+    id: dbRule.id,
+    name: dbRule.name,
+    description: dbRule.description ?? '',
+    type: dbRule.type as Rule['type'],
+    config: dbRule.config as any,
+    mitigations: dbRule.mitigations as any,
+  };
+
+  return evaluate(observations, [rule], defaultRegistry);
+}
+
+/**
+ * Validate a rule config using the evaluator registry.
+ * Throws ValidationError if invalid.
+ */
+function validateConfig(type: string, config: unknown): void {
+  const evaluator = defaultRegistry.get(type);
+  const { valid, errors } = evaluator.validate(config);
+  if (!valid) {
+    throw new ValidationError('Invalid rule configuration', errors);
+  }
+}


### PR DESCRIPTION
## Summary
- Rule service: CRUD with evaluator validation on save, test endpoint (no DB persist)
- Release service: publish (validate all drafts + atomic snapshot), activate with audit logging
- Routes: GET/POST/PUT/DELETE /api/rules, POST /rules/:id/test
- Routes: GET/POST /api/releases, PUT /releases/:id/activate, GET /releases/active/rules
- Role-based: applied_science for management, underwriter for rule reference
- 15 integration tests

## Test Results
15 new tests pass.

Closes #31