### PR TITLE
Iteration 4.5: Admin routes, server entry point, and E2E smoke test

### DIFF
--- a/server/src/__tests__/api/admin.test.ts
+++ b/server/src/__tests__/api/admin.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Integration tests for admin routes:
+ *   GET  /api/admin/settings
+ *   PUT  /api/admin/settings
+ *   GET  /api/admin/users
+ *   POST /api/admin/users
+ *   GET  /api/health
+ *
+ * Uses a dedicated test database. Truncates all tables between tests.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import { hashSync } from 'bcryptjs';
+import { PrismaClient } from '@prisma/client';
+import app from '../../app.js';
+import { signToken } from '../../lib/jwt.js';
+
+// ---------------------------------------------------------------------------
+// Test PrismaClient
+// ---------------------------------------------------------------------------
+
+const testDb = new PrismaClient({
+  datasources: {
+    db: {
+      url: 'postgresql://managpan@localhost:5432/mitigation_rules_engine_test',
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_PASSWORD = 'Test1234!';
+const PASSWORD_HASH = hashSync(TEST_PASSWORD, 4);
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await testDb.$connect();
+});
+
+beforeEach(async () => {
+  await testDb.$executeRawUnsafe(
+    `TRUNCATE TABLE users, rules, releases, release_rules, evaluations,
+     evaluation_mitigations, policy_locks, audit_log, settings
+     CASCADE`,
+  );
+});
+
+afterAll(async () => {
+  await testDb.$disconnect();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedUser(email: string, role = 'admin') {
+  return testDb.user.create({
+    data: { email, passwordHash: PASSWORD_HASH, role },
+  });
+}
+
+function tokenFor(user: { id: string; email: string; role: string }) {
+  return signToken({ userId: user.id, email: user.email, role: user.role });
+}
+
+// ===========================================================================
+// GET /api/admin/settings
+// ===========================================================================
+
+describe('GET /api/admin/settings', () => {
+  it('1 - returns settings for admin user', async () => {
+    const admin = await seedUser('admin@example.com', 'admin');
+    const token = tokenFor(admin);
+
+    // Seed a setting
+    await testDb.setting.create({
+      data: { key: 'bridge_mitigation_limit', value: 5 as any },
+    });
+
+    const res = await request(app)
+      .get('/api/admin/settings')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveProperty('bridge_mitigation_limit');
+    expect(res.body.data.bridge_mitigation_limit).toBe(5);
+  });
+});
+
+// ===========================================================================
+// PUT /api/admin/settings
+// ===========================================================================
+
+describe('PUT /api/admin/settings', () => {
+  it('2 - updates bridge_mitigation_limit', async () => {
+    const admin = await seedUser('admin@example.com', 'admin');
+    const token = tokenFor(admin);
+
+    // Seed initial setting
+    await testDb.setting.create({
+      data: { key: 'bridge_mitigation_limit', value: 3 as any },
+    });
+
+    const res = await request(app)
+      .put('/api/admin/settings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bridge_mitigation_limit: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.bridge_mitigation_limit).toBe(10);
+
+    // Verify it persisted
+    const check = await testDb.setting.findUnique({
+      where: { key: 'bridge_mitigation_limit' },
+    });
+    expect(check?.value).toBe(10);
+  });
+});
+
+// ===========================================================================
+// GET /api/admin/users
+// ===========================================================================
+
+describe('GET /api/admin/users', () => {
+  it('3 - returns users without password hashes', async () => {
+    const admin = await seedUser('admin@example.com', 'admin');
+    await seedUser('underwriter@example.com', 'underwriter');
+    const token = tokenFor(admin);
+
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.data)).toBe(true);
+    expect(res.body.data.length).toBe(2);
+    // No user should expose passwordHash
+    for (const user of res.body.data) {
+      expect(user).toHaveProperty('id');
+      expect(user).toHaveProperty('email');
+      expect(user).toHaveProperty('role');
+      expect(user).not.toHaveProperty('passwordHash');
+      expect(user).not.toHaveProperty('password_hash');
+    }
+  });
+});
+
+// ===========================================================================
+// POST /api/admin/users
+// ===========================================================================
+
+describe('POST /api/admin/users', () => {
+  it('4 - admin creates a new user and gets 201', async () => {
+    const admin = await seedUser('admin@example.com', 'admin');
+    const token = tokenFor(admin);
+
+    const res = await request(app)
+      .post('/api/admin/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        email: 'newuser@example.com',
+        password: 'Secure1234!',
+        role: 'underwriter',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data).toMatchObject({
+      email: 'newuser@example.com',
+      role: 'underwriter',
+    });
+    expect(res.body.data).toHaveProperty('id');
+    expect(res.body.data).not.toHaveProperty('passwordHash');
+  });
+});
+
+// ===========================================================================
+// Non-admin gets 403
+// ===========================================================================
+
+describe('Admin endpoints require admin role', () => {
+  it('5 - non-admin gets 403 on all admin endpoints', async () => {
+    const underwriter = await seedUser('uw@example.com', 'underwriter');
+    const token = tokenFor(underwriter);
+
+    const getSettings = await request(app)
+      .get('/api/admin/settings')
+      .set('Authorization', `Bearer ${token}`);
+    expect(getSettings.status).toBe(403);
+
+    const putSettings = await request(app)
+      .put('/api/admin/settings')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ bridge_mitigation_limit: 5 });
+    expect(putSettings.status).toBe(403);
+
+    const getUsers = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${token}`);
+    expect(getUsers.status).toBe(403);
+
+    const postUsers = await request(app)
+      .post('/api/admin/users')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        email: 'hack@example.com',
+        password: 'Secure1234!',
+        role: 'admin',
+      });
+    expect(postUsers.status).toBe(403);
+  });
+});
+
+// ===========================================================================
+// GET /api/health
+// ===========================================================================
+
+describe('GET /api/health', () => {
+  it('6 - returns 200 without authentication', async () => {
+    const res = await request(app).get('/api/health');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok' });
+  });
+});

--- a/server/src/__tests__/api/smoke.test.ts
+++ b/server/src/__tests__/api/smoke.test.ts
@@ -1,0 +1,271 @@
+/**
+ * End-to-end smoke test that validates the full API flow:
+ *   1. Login as underwriter, evaluate observations, select mitigations, verify result
+ *   2. Login as applied_science, create rule, publish release, activate
+ *   3. Login as admin, update settings
+ *
+ * Uses a dedicated test database. Seeds users and rules via Prisma directly.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
+import request from 'supertest';
+import { hashSync } from 'bcryptjs';
+import { PrismaClient } from '@prisma/client';
+import app from '../../app.js';
+import { signToken } from '../../lib/jwt.js';
+import { SEED_RULES } from '@shared/data/seed-rules.js';
+import { OBS_ATTIC_VENT_FAIL } from '@shared/data/seed-observations.js';
+
+// ---------------------------------------------------------------------------
+// Test PrismaClient
+// ---------------------------------------------------------------------------
+
+const testDb = new PrismaClient({
+  datasources: {
+    db: {
+      url: 'postgresql://managpan@localhost:5432/mitigation_rules_engine_test',
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TEST_PASSWORD = 'Test1234!';
+const PASSWORD_HASH = hashSync(TEST_PASSWORD, 4);
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeAll(async () => {
+  await testDb.$connect();
+});
+
+beforeEach(async () => {
+  await testDb.$executeRawUnsafe(
+    `TRUNCATE TABLE users, rules, releases, release_rules, evaluations,
+     evaluation_mitigations, policy_locks, audit_log, settings
+     CASCADE`,
+  );
+});
+
+afterAll(async () => {
+  await testDb.$disconnect();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedUser(email: string, role: string) {
+  return testDb.user.create({
+    data: { email, passwordHash: PASSWORD_HASH, role },
+  });
+}
+
+function tokenFor(user: { id: string; email: string; role: string }) {
+  return signToken({ userId: user.id, email: user.email, role: user.role });
+}
+
+async function seedRulesAndRelease(userId: string) {
+  // Seed draft rules
+  for (const rule of SEED_RULES) {
+    await testDb.rule.create({
+      data: {
+        id: rule.id,
+        name: rule.name,
+        description: rule.description ?? '',
+        type: rule.type,
+        config: rule.config as any,
+        mitigations: rule.mitigations as any,
+        createdById: userId,
+      },
+    });
+  }
+
+  // Create and activate a release
+  const release = await testDb.release.create({
+    data: { name: 'v1.0-smoke', publishedBy: userId, isActive: true },
+  });
+
+  // Snapshot rules into release_rules
+  for (const rule of SEED_RULES) {
+    await testDb.releaseRule.create({
+      data: {
+        releaseId: release.id,
+        ruleId: rule.id,
+        ruleSnapshot: {
+          id: rule.id,
+          name: rule.name,
+          description: rule.description,
+          type: rule.type,
+          config: rule.config,
+          mitigations: rule.mitigations,
+          version: 1,
+        } as any,
+      },
+    });
+  }
+
+  // Seed bridge limit setting
+  await testDb.setting.upsert({
+    where: { key: 'bridge_mitigation_limit' },
+    update: { value: 3 as any },
+    create: { key: 'bridge_mitigation_limit', value: 3 as any },
+  });
+
+  return release;
+}
+
+// ===========================================================================
+// Smoke Test
+// ===========================================================================
+
+describe('End-to-end smoke test', () => {
+  it('validates the full API flow across all roles', async () => {
+    // ── Seed users ──────────────────────────────────────────────────────
+    const uwUser = await seedUser('underwriter@smoke.com', 'underwriter');
+    const sciUser = await seedUser('scientist@smoke.com', 'applied_science');
+    const adminUser = await seedUser('admin@smoke.com', 'admin');
+
+    // Seed rules + release for initial underwriter flow
+    await seedRulesAndRelease(sciUser.id);
+
+    // ── Step 1: Login as underwriter ────────────────────────────────────
+    const uwLoginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'underwriter@smoke.com', password: TEST_PASSWORD });
+
+    expect(uwLoginRes.status).toBe(200);
+    const uwToken = uwLoginRes.body.data.token;
+    expect(uwToken).toBeTruthy();
+
+    // ── Step 2: Evaluate with OBS_ATTIC_VENT_FAIL ──────────────────────
+    const evalRes = await request(app)
+      .post('/api/evaluate')
+      .set('Authorization', `Bearer ${uwToken}`)
+      .send({ observations: OBS_ATTIC_VENT_FAIL, release_id: null });
+
+    expect(evalRes.status).toBe(200);
+    expect(evalRes.body.data).toHaveProperty('evaluation_id');
+    expect(evalRes.body.data).toHaveProperty('vulnerabilities');
+
+    const evaluationId = evalRes.body.data.evaluation_id;
+    const triggered = evalRes.body.data.vulnerabilities.filter(
+      (v: any) => v.triggered,
+    );
+    expect(triggered.length).toBeGreaterThan(0);
+
+    // ── Step 3: Select a full mitigation ────────────────────────────────
+    const atticVentVuln = triggered.find(
+      (v: any) => v.rule_id === SEED_RULES[0].id,
+    );
+    expect(atticVentVuln).toBeTruthy();
+
+    const mitRes = await request(app)
+      .post(`/api/evaluate/${evaluationId}/mitigations`)
+      .set('Authorization', `Bearer ${uwToken}`)
+      .send({
+        selections: [
+          {
+            rule_id: SEED_RULES[0].id,
+            mitigation_id: SEED_RULES[0].mitigations[0].id,
+            category: 'full',
+          },
+        ],
+      });
+
+    expect(mitRes.status).toBe(200);
+    expect(mitRes.body.data).toEqual({ success: true });
+
+    // ── Step 4: GET evaluation by id ────────────────────────────────────
+    const getEvalRes = await request(app)
+      .get(`/api/evaluations/${evaluationId}`)
+      .set('Authorization', `Bearer ${uwToken}`);
+
+    expect(getEvalRes.status).toBe(200);
+    expect(getEvalRes.body.data.id).toBe(evaluationId);
+    expect(getEvalRes.body.data).toHaveProperty('observations');
+    expect(getEvalRes.body.data).toHaveProperty('result');
+    expect(getEvalRes.body.data.mitigations.length).toBe(1);
+
+    // ── Step 5: Login as applied_science ────────────────────────────────
+    const sciLoginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'scientist@smoke.com', password: TEST_PASSWORD });
+
+    expect(sciLoginRes.status).toBe(200);
+    const sciToken = sciLoginRes.body.data.token;
+
+    // ── Step 6: Create a new rule ───────────────────────────────────────
+    const newRuleRes = await request(app)
+      .post('/api/rules')
+      .set('Authorization', `Bearer ${sciToken}`)
+      .send({
+        name: 'Smoke Test Rule',
+        description: 'A rule created during smoke testing',
+        type: 'simple_threshold',
+        config: {
+          field: 'roof_age',
+          operator: 'gte',
+          value: 30,
+        },
+        mitigations: [
+          {
+            id: 'c0000000-0000-4000-c000-000000000001',
+            name: 'Replace Roof',
+            description: 'Full roof replacement',
+            category: 'full',
+          },
+        ],
+      });
+
+    expect(newRuleRes.status).toBe(201);
+    expect(newRuleRes.body.data).toHaveProperty('id');
+    expect(newRuleRes.body.data.name).toBe('Smoke Test Rule');
+
+    // ── Step 7: Publish a new release ───────────────────────────────────
+    const publishRes = await request(app)
+      .post('/api/releases')
+      .set('Authorization', `Bearer ${sciToken}`)
+      .send({ name: 'v2.0-smoke' });
+
+    expect(publishRes.status).toBe(201);
+    const newReleaseId = publishRes.body.data.id;
+
+    // ── Step 8: Activate the new release ────────────────────────────────
+    const activateRes = await request(app)
+      .put(`/api/releases/${newReleaseId}/activate`)
+      .set('Authorization', `Bearer ${sciToken}`);
+
+    expect(activateRes.status).toBe(200);
+    expect(activateRes.body.data.isActive).toBe(true);
+
+    // ── Step 9: Login as admin ──────────────────────────────────────────
+    const adminLoginRes = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'admin@smoke.com', password: TEST_PASSWORD });
+
+    expect(adminLoginRes.status).toBe(200);
+    const adminToken = adminLoginRes.body.data.token;
+
+    // ── Step 10: Update settings (bridge limit) ─────────────────────────
+    const settingsRes = await request(app)
+      .put('/api/admin/settings')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ bridge_mitigation_limit: 5 });
+
+    expect(settingsRes.status).toBe(200);
+    expect(settingsRes.body.data.bridge_mitigation_limit).toBe(5);
+
+    // Verify the setting persisted
+    const getSettingsRes = await request(app)
+      .get('/api/admin/settings')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(getSettingsRes.status).toBe(200);
+    expect(getSettingsRes.body.data.bridge_mitigation_limit).toBe(5);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -5,16 +5,22 @@ import authRoutes from './routes/auth.routes.js';
 import ruleRoutes from './routes/rule.routes.js';
 import releaseRoutes from './routes/release.routes.js';
 import evaluationRoutes from './routes/evaluation.routes.js';
+import adminRoutes from './routes/admin.routes.js';
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
+app.get('/api/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
 app.use('/api/auth', authRoutes);
 app.use('/api/rules', ruleRoutes);
 app.use('/api/releases', releaseRoutes);
 app.use('/api', evaluationRoutes);
+app.use('/api/admin', adminRoutes);
 
 app.use(errorHandler);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,7 @@
+import app from './app.js';
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -1,0 +1,81 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { authMiddleware, requireRole, validateBody } from '../middleware/index.js';
+import { UpdateSettingsRequestSchema } from '@shared/schemas/settings.schema.js';
+import { CreateUserRequestSchema } from '@shared/schemas/user.schema.js';
+import * as adminService from '../services/admin.service.js';
+import type { ApiResponse } from '@shared/types/api.js';
+import type { User } from '@shared/types/user.js';
+
+const router = Router();
+
+// All admin routes require auth + admin role
+router.use(authMiddleware, requireRole('admin'));
+
+/**
+ * GET / -- get all settings
+ */
+router.get(
+  '/settings',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const settings = await adminService.getSettings();
+      const body: ApiResponse<typeof settings> = { data: settings };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * PUT /settings -- update settings
+ */
+router.put(
+  '/settings',
+  validateBody(UpdateSettingsRequestSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const settings = await adminService.updateSettings(req.body);
+      const body: ApiResponse<typeof settings> = { data: settings };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * GET /users -- list all users (no password hashes)
+ */
+router.get(
+  '/users',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const users = await adminService.listUsers();
+      const body: ApiResponse<User[]> = { data: users };
+      res.json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+/**
+ * POST /users -- create a new user
+ */
+router.post(
+  '/users',
+  validateBody(CreateUserRequestSchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { email, password, role } = req.body;
+      const user = await adminService.createUser(email, password, role);
+      const body: ApiResponse<User> = { data: user };
+      res.status(201).json(body);
+    } catch (err) {
+      next(err);
+    }
+  },
+);
+
+export default router;

--- a/server/src/services/admin.service.ts
+++ b/server/src/services/admin.service.ts
@@ -1,0 +1,43 @@
+import { settingsRepository } from '../db/repositories/settings.repository.js';
+import { userRepository } from '../db/repositories/user.repository.js';
+import * as authService from './auth.service.js';
+import type { User } from '@shared/types/user.js';
+
+/**
+ * Get all settings as a key-value map.
+ */
+export async function getSettings(): Promise<Record<string, unknown>> {
+  return settingsRepository.getAll();
+}
+
+/**
+ * Update settings. Each key in the data object is upserted individually.
+ * Returns the full settings map after updates.
+ */
+export async function updateSettings(
+  data: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  for (const [key, value] of Object.entries(data)) {
+    await settingsRepository.set(key, value);
+  }
+  return settingsRepository.getAll();
+}
+
+/**
+ * List all users without exposing password hashes.
+ */
+export async function listUsers(): Promise<User[]> {
+  const users = await userRepository.list();
+  return users.map((u) => ({ id: u.id, email: u.email, role: u.role as User['role'] }));
+}
+
+/**
+ * Create a new user by delegating to the auth service register function.
+ */
+export async function createUser(
+  email: string,
+  password: string,
+  role: string,
+): Promise<User> {
+  return authService.register(email, password, role);
+}


### PR DESCRIPTION
## Summary
- Admin service: get/update settings, list users (no password hashes), create users
- Admin routes: GET/PUT /api/admin/settings, GET/POST /api/admin/users (admin-only)
- Health check: GET /api/health (unauthenticated)
- Server entry point: /server/src/index.ts
- 6 admin integration tests + 1 full E2E smoke test

## E2E Smoke Test
Validates the entire API flow:
1. Underwriter: login → evaluate → select mitigations → verify result
2. Applied Science: login → create rule → publish release → activate
3. Admin: login → update bridge limit

## Test Results
7 new tests pass. 127/128 total (1 pre-existing failure in rules.test.ts unrelated to this change).

Closes #32