### PR TITLE
Fix: computed rule actualValue extraction

### DIFF
--- a/client/src/components/evaluation/vulnerability-card.tsx
+++ b/client/src/components/evaluation/vulnerability-card.tsx
@@ -207,9 +207,12 @@ export function VulnerabilityCard({
 
   // For computed rules: extract base threshold and actual value for bridge stacker
   const computedThreshold = vulnerability.details.computedThreshold;
+  const itemBreakdown = (vulnerability.details as any).itemBreakdown as
+    | Array<{ actualValue: number; threshold: number; passes: boolean }>
+    | undefined;
   const actualValue =
-    computedThreshold != null
-      ? (Object.values(vulnerability.details.observedValues)[0] as number)
+    computedThreshold != null && itemBreakdown?.length
+      ? itemBreakdown[0].actualValue
       : null;
 
   // Selected bridges for the stacker


### PR DESCRIPTION
Extract actualValue from itemBreakdown instead of observedValues for computed rules. Fixes crash when rendering Windows rule results.