### PR TITLE
Iteration 6.2: Rule editor with type-specific forms and mitigation editor

### DIFF
--- a/client/src/components/rules/mitigation-editor.tsx
+++ b/client/src/components/rules/mitigation-editor.tsx
@@ -1,0 +1,213 @@
+import type { Mitigation, BridgeEffect } from '@shared/types/rule.js';
+
+interface MitigationEditorProps {
+  mitigations: Mitigation[];
+  onChange: (mitigations: Mitigation[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function PlusIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMitigation(category: 'full' | 'bridge'): Mitigation {
+  const base = { id: crypto.randomUUID(), name: '', description: '', category };
+  if (category === 'bridge') {
+    return { ...base, effect: { type: 'multiplier' as const, value: 1 } };
+  }
+  return base as Mitigation;
+}
+
+const CATEGORY_STYLES = {
+  full: { bg: 'bg-green-50', border: 'border-green-200', badge: 'bg-green-100 text-green-700', label: 'Full Mitigation' },
+  bridge: { bg: 'bg-amber-50', border: 'border-amber-200', badge: 'bg-amber-100 text-amber-700', label: 'Bridge Mitigation' },
+};
+
+// ---------------------------------------------------------------------------
+// Single mitigation card
+// ---------------------------------------------------------------------------
+
+function MitigationCard({
+  mitigation,
+  onChange,
+  onRemove,
+}: {
+  mitigation: Mitigation;
+  onChange: (m: Mitigation) => void;
+  onRemove: () => void;
+}) {
+  const style = CATEGORY_STYLES[mitigation.category];
+
+  function handleCategoryChange(category: 'full' | 'bridge') {
+    if (category === 'full') {
+      // Remove effect for full mitigations
+      const { effect: _, ...rest } = mitigation as any;
+      onChange({ ...rest, category: 'full' } as Mitigation);
+    } else {
+      // Add default effect for bridge
+      onChange({
+        ...mitigation,
+        category: 'bridge',
+        effect: { type: 'multiplier', value: 1 },
+      } as Mitigation);
+    }
+  }
+
+  function handleEffectTypeChange(effectType: 'multiplier' | 'override') {
+    if (effectType === 'multiplier') {
+      onChange({ ...mitigation, effect: { type: 'multiplier', value: 1 } } as Mitigation);
+    } else {
+      onChange({ ...mitigation, effect: { type: 'override', value: '' } } as Mitigation);
+    }
+  }
+
+  const effect = (mitigation as any).effect as BridgeEffect | undefined;
+
+  return (
+    <div className={`p-4 ${style.bg} rounded-lg border ${style.border}`}>
+      <div className="flex items-center justify-between mb-3">
+        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${style.badge}`}>
+          {style.label}
+        </span>
+        <button type="button" onClick={onRemove} className="p-1 text-gray-400 hover:text-red-500 rounded">
+          <CloseIcon />
+        </button>
+      </div>
+
+      <div className={`grid grid-cols-1 ${mitigation.category === 'bridge' ? 'sm:grid-cols-3' : 'sm:grid-cols-2'} gap-3`}>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Name <span className="text-red-500">*</span></label>
+          <input
+            type="text"
+            value={mitigation.name}
+            onChange={(e) => onChange({ ...mitigation, name: e.target.value })}
+            placeholder="e.g., Replace with Tempered Glass"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-500 mb-1">Category</label>
+          <select
+            value={mitigation.category}
+            onChange={(e) => handleCategoryChange(e.target.value as 'full' | 'bridge')}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="full">Full Mitigation</option>
+            <option value="bridge">Bridge Mitigation</option>
+          </select>
+        </div>
+
+        {/* Bridge effect config */}
+        {mitigation.category === 'bridge' && effect && (
+          <div>
+            <label className="block text-xs text-gray-500 mb-1">Bridge Effect</label>
+            <div className="flex gap-2">
+              <select
+                value={effect.type}
+                onChange={(e) => handleEffectTypeChange(e.target.value as 'multiplier' | 'override')}
+                className="rounded-md border border-gray-300 px-2 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value="multiplier">Multiplier</option>
+                <option value="override">Override</option>
+              </select>
+              <input
+                type={effect.type === 'multiplier' ? 'number' : 'text'}
+                step={effect.type === 'multiplier' ? '0.1' : undefined}
+                value={effect.value}
+                onChange={(e) => {
+                  const val = effect.type === 'multiplier' ? Number(e.target.value) || 0 : e.target.value;
+                  onChange({ ...mitigation, effect: { ...effect, value: val } } as Mitigation);
+                }}
+                placeholder={effect.type === 'multiplier' ? '0.8' : 'override value'}
+                className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Description spans full row */}
+        <div className={mitigation.category === 'bridge' ? 'sm:col-span-3' : 'sm:col-span-2'}>
+          <label className="block text-xs text-gray-500 mb-1">Description <span className="text-red-500">*</span></label>
+          <input
+            type="text"
+            value={mitigation.description}
+            onChange={(e) => onChange({ ...mitigation, description: e.target.value })}
+            placeholder="Describe what this mitigation involves"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MitigationEditor
+// ---------------------------------------------------------------------------
+
+export function MitigationEditor({ mitigations, onChange }: MitigationEditorProps) {
+  function updateMitigation(index: number, m: Mitigation) {
+    const updated = [...mitigations];
+    updated[index] = m;
+    onChange(updated);
+  }
+
+  function removeMitigation(index: number) {
+    onChange(mitigations.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-semibold text-gray-900">Mitigations</h3>
+        <button
+          type="button"
+          onClick={() => onChange([...mitigations, createMitigation('full')])}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
+        >
+          <PlusIcon />
+          Add Mitigation
+        </button>
+      </div>
+      <p className="text-xs text-gray-400 mb-4">
+        If no mitigations are defined, the rule will be unmitigatable (auto-decline on failure).
+      </p>
+
+      {mitigations.length === 0 ? (
+        <div className="text-center py-8 text-sm text-gray-500 border border-dashed border-gray-300 rounded-lg">
+          No mitigations defined. This rule will auto-decline on failure.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {mitigations.map((m, index) => (
+            <MitigationCard
+              key={m.id}
+              mitigation={m}
+              onChange={(updated) => updateMitigation(index, updated)}
+              onRemove={() => removeMitigation(index)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/rules/rule-form-computed.tsx
+++ b/client/src/components/rules/rule-form-computed.tsx
@@ -1,0 +1,274 @@
+import type { ComputedConfig, Modifier } from '@shared/types/rule.js';
+
+interface RuleFormComputedProps {
+  config: ComputedConfig;
+  onChange: (config: ComputedConfig) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function PlusIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mapping editor for a single modifier
+// ---------------------------------------------------------------------------
+
+function MappingEditor({
+  mapping,
+  onChange,
+}: {
+  mapping: Record<string, number>;
+  onChange: (mapping: Record<string, number>) => void;
+}) {
+  const entries = Object.entries(mapping);
+
+  function updateEntry(oldKey: string, newKey: string, value: number) {
+    const updated: Record<string, number> = {};
+    for (const [k, v] of entries) {
+      if (k === oldKey) {
+        updated[newKey] = value;
+      } else {
+        updated[k] = v;
+      }
+    }
+    onChange(updated);
+  }
+
+  function addEntry() {
+    onChange({ ...mapping, '': 0 });
+  }
+
+  function removeEntry(key: string) {
+    const { [key]: _, ...rest } = mapping;
+    onChange(rest);
+  }
+
+  return (
+    <div>
+      <label className="block text-xs text-gray-500 mb-1">Value Mapping</label>
+      <div className="space-y-1.5">
+        {entries.map(([key, value], index) => (
+          <div key={index} className="flex gap-2 items-center">
+            <input
+              type="text"
+              value={key}
+              onChange={(e) => updateEntry(key, e.target.value, value)}
+              placeholder="Value"
+              className="flex-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <span className="text-gray-400 text-sm">=</span>
+            <input
+              type="number"
+              value={value}
+              onChange={(e) => updateEntry(key, key, Number(e.target.value) || 0)}
+              className="w-20 rounded-md border border-gray-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <button
+              type="button"
+              onClick={() => removeEntry(key)}
+              className="p-1 text-gray-400 hover:text-red-500 rounded"
+            >
+              <CloseIcon />
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={addEntry}
+        className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700"
+      >
+        <PlusIcon />
+        Add mapping
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Default modifier
+// ---------------------------------------------------------------------------
+
+function emptyModifier(): Modifier {
+  return { field: '', mapping: {}, operation: 'multiply' };
+}
+
+// ---------------------------------------------------------------------------
+// RuleFormComputed
+// ---------------------------------------------------------------------------
+
+export function RuleFormComputed({ config, onChange }: RuleFormComputedProps) {
+  function updateModifier(index: number, modifier: Modifier) {
+    const modifiers = [...config.modifiers];
+    modifiers[index] = modifier;
+    onChange({ ...config, modifiers });
+  }
+
+  function addModifier() {
+    onChange({ ...config, modifiers: [...config.modifiers, emptyModifier()] });
+  }
+
+  function removeModifier(index: number) {
+    const modifiers = config.modifiers.filter((_, i) => i !== index);
+    onChange({ ...config, modifiers: modifiers.length > 0 ? modifiers : [emptyModifier()] });
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+      <h3 className="text-base font-semibold text-gray-900 mb-4">Computed Configuration</h3>
+
+      {/* Top-level fields */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 mb-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Base Value <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="number"
+            value={config.baseValue}
+            onChange={(e) => onChange({ ...config, baseValue: Number(e.target.value) || 0 })}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Unit <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={config.unit}
+            onChange={(e) => onChange({ ...config, unit: e.target.value })}
+            placeholder="e.g., feet"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Comparison Field <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={config.comparisonField}
+            onChange={(e) => onChange({ ...config, comparisonField: e.target.value })}
+            placeholder="e.g., vegetation[].distance_to_window"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Comparison Operator</label>
+          <select
+            value={config.comparisonOperator}
+            onChange={(e) =>
+              onChange({ ...config, comparisonOperator: e.target.value as 'gte' | 'gt' })
+            }
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            <option value="gte">Pass if actual &gt;= threshold</option>
+            <option value="gt">Pass if actual &gt; threshold</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Array Field (optional)</label>
+          <input
+            type="text"
+            value={config.arrayField ?? ''}
+            onChange={(e) =>
+              onChange({ ...config, arrayField: e.target.value || undefined })
+            }
+            placeholder="e.g., vegetation"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <p className="text-xs text-gray-400 mt-1">If set, each item in the array is evaluated independently</p>
+        </div>
+      </div>
+
+      {/* Modifiers */}
+      <div className="border-t border-gray-200 pt-5">
+        <div className="flex items-center justify-between mb-3">
+          <h4 className="text-sm font-semibold text-gray-900">Modifiers</h4>
+          <button
+            type="button"
+            onClick={addModifier}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
+          >
+            <PlusIcon />
+            Add Modifier
+          </button>
+        </div>
+        <div className="space-y-3">
+          {config.modifiers.map((modifier, index) => (
+            <div key={index} className="p-4 bg-gray-50 rounded-lg border border-gray-200">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-xs font-semibold text-gray-500 uppercase">
+                  Modifier {index + 1}
+                </span>
+                {config.modifiers.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={() => removeModifier(index)}
+                    className="p-1 text-gray-400 hover:text-red-500 rounded"
+                  >
+                    <CloseIcon />
+                  </button>
+                )}
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-3">
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Field</label>
+                  <input
+                    type="text"
+                    value={modifier.field}
+                    onChange={(e) =>
+                      updateModifier(index, { ...modifier, field: e.target.value })
+                    }
+                    placeholder="e.g., window_type"
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+                <div>
+                  <label className="block text-xs text-gray-500 mb-1">Operation</label>
+                  <select
+                    value={modifier.operation}
+                    onChange={(e) =>
+                      updateModifier(index, {
+                        ...modifier,
+                        operation: e.target.value as 'multiply' | 'divide',
+                      })
+                    }
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    <option value="multiply">Multiply (x)</option>
+                    <option value="divide">Divide (/)</option>
+                  </select>
+                </div>
+              </div>
+              <MappingEditor
+                mapping={modifier.mapping}
+                onChange={(mapping) => updateModifier(index, { ...modifier, mapping })}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/rules/rule-form-conditional.tsx
+++ b/client/src/components/rules/rule-form-conditional.tsx
@@ -1,0 +1,181 @@
+import type { ConditionalConfig, ThresholdCheck, ConditionalBranch } from '@shared/types/rule.js';
+
+const OPERATORS = [
+  { value: 'eq', label: 'equals (=)' },
+  { value: 'neq', label: 'not equals (!=)' },
+  { value: 'in', label: 'in list' },
+  { value: 'gte', label: 'greater or equal (>=)' },
+  { value: 'lte', label: 'less or equal (<=)' },
+  { value: 'gt', label: 'greater than (>)' },
+  { value: 'lt', label: 'less than (<)' },
+] as const;
+
+interface RuleFormConditionalProps {
+  config: ConditionalConfig;
+  onChange: (config: ConditionalConfig) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Threshold check row (reused for when, then, default)
+// ---------------------------------------------------------------------------
+
+function ThresholdRow({
+  check,
+  onChange,
+}: {
+  check: ThresholdCheck;
+  onChange: (check: ThresholdCheck) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 gap-3">
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">Field</label>
+        <input
+          type="text"
+          value={check.field}
+          onChange={(e) => onChange({ ...check, field: e.target.value })}
+          placeholder="e.g., roof_type"
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">Operator</label>
+        <select
+          value={check.operator}
+          onChange={(e) => onChange({ ...check, operator: e.target.value as ThresholdCheck['operator'] })}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          {OPERATORS.map((op) => (
+            <option key={op.value} value={op.value}>
+              {op.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="block text-xs text-gray-500 mb-1">Value</label>
+        <input
+          type="text"
+          value={Array.isArray(check.value) ? check.value.join(', ') : String(check.value)}
+          onChange={(e) => {
+            const raw = e.target.value;
+            if (check.operator === 'in') {
+              onChange({ ...check, value: raw.split(',').map((s) => s.trim()) });
+            } else {
+              const num = Number(raw);
+              onChange({ ...check, value: raw === '' ? '' : isNaN(num) ? raw : num });
+            }
+          }}
+          placeholder={check.operator === 'in' ? 'A, B, C' : 'value'}
+          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function PlusIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+    </svg>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+function emptyCheck(): ThresholdCheck {
+  return { field: '', operator: 'eq', value: '' };
+}
+
+function emptyBranch(): ConditionalBranch {
+  return { when: emptyCheck(), then: emptyCheck() };
+}
+
+// ---------------------------------------------------------------------------
+// RuleFormConditional
+// ---------------------------------------------------------------------------
+
+export function RuleFormConditional({ config, onChange }: RuleFormConditionalProps) {
+  function updateCondition(index: number, branch: ConditionalBranch) {
+    const conditions = [...config.conditions];
+    conditions[index] = branch;
+    onChange({ ...config, conditions });
+  }
+
+  function addCondition() {
+    onChange({ ...config, conditions: [...config.conditions, emptyBranch()] });
+  }
+
+  function removeCondition(index: number) {
+    const conditions = config.conditions.filter((_, i) => i !== index);
+    onChange({ ...config, conditions: conditions.length > 0 ? conditions : [emptyBranch()] });
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-semibold text-gray-900">Conditional Branches</h3>
+        <button
+          type="button"
+          onClick={addCondition}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-md hover:bg-blue-100 transition-colors"
+        >
+          <PlusIcon />
+          Add Condition
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        {config.conditions.map((branch, index) => (
+          <div key={index} className="p-4 bg-purple-50 rounded-lg border border-purple-100">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-xs font-semibold text-purple-600 uppercase">WHEN</p>
+              {config.conditions.length > 1 && (
+                <button
+                  type="button"
+                  onClick={() => removeCondition(index)}
+                  className="p-1 text-gray-400 hover:text-red-500 rounded"
+                >
+                  <CloseIcon />
+                </button>
+              )}
+            </div>
+            <ThresholdRow
+              check={branch.when}
+              onChange={(when) => updateCondition(index, { ...branch, when })}
+            />
+            <p className="text-xs font-semibold text-purple-600 uppercase mt-3 mb-2">THEN</p>
+            <ThresholdRow
+              check={branch.then}
+              onChange={(then) => updateCondition(index, { ...branch, then })}
+            />
+          </div>
+        ))}
+
+        {/* Default */}
+        <div className="p-4 bg-gray-50 rounded-lg border border-gray-200">
+          <p className="text-xs font-semibold text-gray-500 uppercase mb-2">DEFAULT (no condition match)</p>
+          <ThresholdRow
+            check={config.default}
+            onChange={(def) => onChange({ ...config, default: def })}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/rules/rule-form-simple.tsx
+++ b/client/src/components/rules/rule-form-simple.tsx
@@ -1,0 +1,81 @@
+import type { SimpleConfig } from '@shared/types/rule.js';
+
+const OPERATORS = [
+  { value: 'eq', label: 'equals (=)' },
+  { value: 'neq', label: 'not equals (!=)' },
+  { value: 'in', label: 'in list' },
+  { value: 'gte', label: 'greater or equal (>=)' },
+  { value: 'lte', label: 'less or equal (<=)' },
+  { value: 'gt', label: 'greater than (>)' },
+  { value: 'lt', label: 'less than (<)' },
+] as const;
+
+interface RuleFormSimpleProps {
+  config: SimpleConfig;
+  onChange: (config: SimpleConfig) => void;
+}
+
+export function RuleFormSimple({ config, onChange }: RuleFormSimpleProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+      <h3 className="text-base font-semibold text-gray-900 mb-4">Simple Threshold Configuration</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Field <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={config.field}
+            onChange={(e) => onChange({ ...config, field: e.target.value })}
+            placeholder="e.g., attic_vent_screens"
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Operator <span className="text-red-500">*</span>
+          </label>
+          <select
+            value={config.operator}
+            onChange={(e) => onChange({ ...config, operator: e.target.value as SimpleConfig['operator'] })}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          >
+            {OPERATORS.map((op) => (
+              <option key={op.value} value={op.value}>
+                {op.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Value <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={
+              Array.isArray(config.value) ? config.value.join(', ') : String(config.value)
+            }
+            onChange={(e) => {
+              const raw = e.target.value;
+              // If operator is "in", treat as comma-separated list
+              if (config.operator === 'in') {
+                onChange({ ...config, value: raw.split(',').map((s) => s.trim()) });
+              } else {
+                // Try to parse as number
+                const num = Number(raw);
+                onChange({ ...config, value: raw === '' ? '' : isNaN(num) ? raw : num });
+              }
+            }}
+            placeholder={config.operator === 'in' ? 'e.g., Class A, Class B' : 'e.g., Ember Resistant'}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+          />
+          {config.operator === 'in' && (
+            <p className="text-xs text-gray-400 mt-1">Comma-separated values</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/rules/editor.tsx
+++ b/client/src/pages/rules/editor.tsx
@@ -1,0 +1,422 @@
+import { useState, useEffect } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useRule, useCreateRule, useUpdateRule } from '@/hooks/useRules';
+import { ApiClientError } from '@/lib/api';
+import { RuleFormSimple } from '@/components/rules/rule-form-simple';
+import { RuleFormConditional } from '@/components/rules/rule-form-conditional';
+import { RuleFormComputed } from '@/components/rules/rule-form-computed';
+import { MitigationEditor } from '@/components/rules/mitigation-editor';
+import type { RuleType, SimpleConfig, ConditionalConfig, ComputedConfig, Mitigation } from '@shared/types/rule.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type RuleConfig = SimpleConfig | ConditionalConfig | ComputedConfig;
+
+interface RuleFormState {
+  name: string;
+  description: string;
+  type: RuleType;
+  config: RuleConfig;
+  mitigations: Mitigation[];
+  version: number;
+}
+
+// ---------------------------------------------------------------------------
+// Defaults per type
+// ---------------------------------------------------------------------------
+
+const DEFAULT_CONFIGS: Record<RuleType, RuleConfig> = {
+  simple_threshold: { field: '', operator: 'eq', value: '' } as SimpleConfig,
+  conditional_threshold: {
+    conditions: [{ when: { field: '', operator: 'eq', value: '' }, then: { field: '', operator: 'eq', value: '' } }],
+    default: { field: '', operator: 'eq', value: '' },
+  } as ConditionalConfig,
+  computed_with_modifiers: {
+    baseValue: 0,
+    unit: '',
+    modifiers: [{ field: '', mapping: {}, operation: 'multiply' }],
+    comparisonField: '',
+    comparisonOperator: 'gte',
+  } as ComputedConfig,
+};
+
+function defaultFormState(): RuleFormState {
+  return {
+    name: '',
+    description: '',
+    type: 'simple_threshold',
+    config: { ...DEFAULT_CONFIGS.simple_threshold },
+    mitigations: [],
+    version: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function SpinnerIcon() {
+  return (
+    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg className="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4" />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Type selector card
+// ---------------------------------------------------------------------------
+
+const TYPE_OPTIONS: { value: RuleType; label: string; desc: string; color: string; iconColor: string }[] = [
+  {
+    value: 'simple_threshold',
+    label: 'Simple Threshold',
+    desc: 'Single field comparison',
+    color: 'blue',
+    iconColor: 'bg-blue-50 text-blue-600',
+  },
+  {
+    value: 'conditional_threshold',
+    label: 'Conditional Threshold',
+    desc: 'When/then branches',
+    color: 'purple',
+    iconColor: 'bg-purple-50 text-purple-600',
+  },
+  {
+    value: 'computed_with_modifiers',
+    label: 'Computed with Modifiers',
+    desc: 'Base value + modifiers',
+    color: 'amber',
+    iconColor: 'bg-amber-50 text-amber-600',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Version conflict banner
+// ---------------------------------------------------------------------------
+
+function ConflictBanner({ onReload }: { onReload: () => void }) {
+  return (
+    <div className="mb-6 rounded-lg border border-amber-300 bg-amber-50 p-4 flex items-center justify-between">
+      <div>
+        <p className="text-sm font-medium text-amber-800">Version conflict</p>
+        <p className="text-sm text-amber-700">
+          This rule was modified by another user. Reload to get the latest version.
+        </p>
+      </div>
+      <button
+        onClick={onReload}
+        className="px-4 py-2 text-sm font-medium text-amber-700 bg-white border border-amber-300 rounded-lg hover:bg-amber-50 transition-colors"
+      >
+        Reload
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RuleEditorPage
+// ---------------------------------------------------------------------------
+
+export function RuleEditorPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const isNew = !id || id === 'new';
+
+  const { data: existingRule, isLoading: isLoadingRule, refetch } = useRule(isNew ? undefined : id);
+  const createRule = useCreateRule();
+  const updateRule = useUpdateRule();
+
+  const [form, setForm] = useState<RuleFormState>(defaultFormState);
+  const [hasConflict, setHasConflict] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<'form' | 'json'>('form');
+
+  // Populate form from loaded rule
+  useEffect(() => {
+    if (existingRule && !isNew) {
+      setForm({
+        name: existingRule.name,
+        description: existingRule.description ?? '',
+        type: existingRule.type as RuleType,
+        config: existingRule.config as RuleConfig,
+        mitigations: existingRule.mitigations as Mitigation[],
+        version: existingRule.version,
+      });
+      setHasConflict(false);
+      setSaveError(null);
+    }
+  }, [existingRule, isNew]);
+
+  function handleTypeChange(type: RuleType) {
+    setForm((prev) => ({
+      ...prev,
+      type,
+      config: { ...DEFAULT_CONFIGS[type] },
+    }));
+  }
+
+  function handleReload() {
+    refetch();
+    setHasConflict(false);
+    setSaveError(null);
+  }
+
+  async function handleSave() {
+    setSaveError(null);
+    setHasConflict(false);
+
+    try {
+      if (isNew) {
+        const created = await createRule.mutateAsync({
+          name: form.name,
+          description: form.description,
+          type: form.type,
+          config: form.config,
+          mitigations: form.mitigations,
+        });
+        navigate(`/rules/${created.id}`, { replace: true });
+      } else {
+        await updateRule.mutateAsync({
+          id: id!,
+          version: form.version,
+          name: form.name,
+          description: form.description,
+          type: form.type,
+          config: form.config,
+          mitigations: form.mitigations,
+        });
+        // Refetch to get updated version
+        refetch();
+      }
+    } catch (err) {
+      if (err instanceof ApiClientError && err.code === 'CONFLICT') {
+        setHasConflict(true);
+      } else if (err instanceof ApiClientError) {
+        setSaveError(err.message);
+      } else {
+        setSaveError('An unexpected error occurred.');
+      }
+    }
+  }
+
+  const isSaving = createRule.isPending || updateRule.isPending;
+
+  // Loading state for editing existing rule
+  if (!isNew && isLoadingRule) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <SpinnerIcon />
+        <span className="ml-2 text-sm text-gray-500">Loading rule...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-8 py-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-gray-900">
+            {isNew ? 'New Rule' : `Edit Rule: ${form.name || 'Untitled'}`}
+          </h2>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {isNew ? 'Create a new underwriting rule' : `Draft — v${form.version}`}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          {/* View toggle */}
+          <div className="inline-flex rounded-lg border border-gray-300 overflow-hidden">
+            <button
+              onClick={() => setViewMode('form')}
+              className={`px-3 py-1.5 text-xs font-medium ${
+                viewMode === 'form' ? 'bg-blue-50 text-blue-700' : 'text-gray-500 hover:bg-gray-50'
+              } border-r border-gray-300`}
+            >
+              Form View
+            </button>
+            <button
+              onClick={() => setViewMode('json')}
+              className={`px-3 py-1.5 text-xs font-medium ${
+                viewMode === 'json' ? 'bg-blue-50 text-blue-700' : 'text-gray-500 hover:bg-gray-50'
+              }`}
+            >
+              JSON Editor
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Conflict banner */}
+      {hasConflict && <ConflictBanner onReload={handleReload} />}
+
+      {/* Save error */}
+      {saveError && (
+        <div className="mb-6 rounded-lg border border-red-300 bg-red-50 p-4">
+          <p className="text-sm text-red-700">{saveError}</p>
+        </div>
+      )}
+
+      {/* Form View */}
+      {viewMode === 'form' && (
+        <>
+          {/* Basic Information */}
+          <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+            <h3 className="text-base font-semibold text-gray-900 mb-4">Basic Information</h3>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Rule Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+                  placeholder="e.g., Window Safety Distance"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+              {!isNew && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Rule ID</label>
+                  <input
+                    type="text"
+                    value={id}
+                    disabled
+                    className="w-full rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-500"
+                  />
+                </div>
+              )}
+              <div className={isNew ? '' : 'sm:col-span-2'}>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Description <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  rows={2}
+                  value={form.description}
+                  onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+                  placeholder="Describe what this rule checks"
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Rule Type Selector */}
+          <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+            <h3 className="text-base font-semibold text-gray-900 mb-4">
+              Rule Type <span className="text-red-500">*</span>
+            </h3>
+            <div className="grid grid-cols-3 gap-4">
+              {TYPE_OPTIONS.map((opt) => {
+                const isSelected = form.type === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={() => handleTypeChange(opt.value)}
+                    className={`rounded-lg border-2 p-4 text-center transition-all ${
+                      isSelected
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-gray-200 hover:border-gray-300'
+                    }`}
+                  >
+                    <div className={`w-10 h-10 mx-auto rounded-full ${opt.iconColor} flex items-center justify-center mb-2`}>
+                      {isSelected ? <CheckIcon /> : (
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4" />
+                        </svg>
+                      )}
+                    </div>
+                    <p className="text-sm font-medium text-gray-900">{opt.label}</p>
+                    <p className="text-xs text-gray-500 mt-1">{opt.desc}</p>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Type-specific config form */}
+          {form.type === 'simple_threshold' && (
+            <RuleFormSimple
+              config={form.config as SimpleConfig}
+              onChange={(config) => setForm((prev) => ({ ...prev, config }))}
+            />
+          )}
+          {form.type === 'conditional_threshold' && (
+            <RuleFormConditional
+              config={form.config as ConditionalConfig}
+              onChange={(config) => setForm((prev) => ({ ...prev, config }))}
+            />
+          )}
+          {form.type === 'computed_with_modifiers' && (
+            <RuleFormComputed
+              config={form.config as ComputedConfig}
+              onChange={(config) => setForm((prev) => ({ ...prev, config }))}
+            />
+          )}
+
+          {/* Mitigations */}
+          <MitigationEditor
+            mitigations={form.mitigations}
+            onChange={(mitigations) => setForm((prev) => ({ ...prev, mitigations }))}
+          />
+        </>
+      )}
+
+      {/* JSON View — placeholder for 6.3 */}
+      {viewMode === 'json' && (
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+          <div className="text-center py-12 text-sm text-gray-500">
+            JSON Editor — coming in iteration 6.3
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center justify-between pb-8">
+        <button
+          type="button"
+          onClick={() => navigate('/rules')}
+          className="px-4 py-2 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          Cancel
+        </button>
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving || !form.name || !form.description}
+            className="px-5 py-2.5 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+          >
+            {isSaving && <SpinnerIcon />}
+            {isNew ? 'Create Rule' : 'Save Changes'}
+          </button>
+          {!isNew && (
+            <button
+              type="button"
+              onClick={() => navigate(`/rules/test?ruleId=${id}`)}
+              className="px-5 py-2.5 text-sm font-medium text-amber-700 bg-amber-50 border border-amber-200 rounded-lg hover:bg-amber-100 transition-colors flex items-center gap-2"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+              Test Rule
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/routes.tsx
+++ b/client/src/routes.tsx
@@ -13,6 +13,7 @@ import { EvaluationResultsPage } from '@/pages/evaluation/results';
 import { EvaluationHistoryPage } from '@/pages/evaluation/history';
 import { EvaluationDetailPage } from '@/pages/evaluation/detail';
 import { RuleListPage } from '@/pages/rules/list';
+import { RuleEditorPage } from '@/pages/rules/editor';
 
 const routes: RouteObject[] = [
   {
@@ -52,6 +53,14 @@ const routes: RouteObject[] = [
           {
             path: 'rules',
             element: <RuleListPage />,
+          },
+          {
+            path: 'rules/new',
+            element: <RuleEditorPage />,
+          },
+          {
+            path: 'rules/:id',
+            element: <RuleEditorPage />,
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Add rule editor page with create (`/rules/new`) and edit (`/rules/:id`) modes
- Form/JSON view toggle (JSON editor placeholder for 6.3)
- Type selector switches between Simple, Conditional, and Computed config forms
- Simple: field, operator, value with auto-detect numeric/string/list
- Conditional: dynamic when/then branches with add/remove + default fallback
- Computed: base value, unit, comparison config, dynamic modifier rows with value mapping editor
- Mitigation editor: add/remove mitigations, full/bridge category, bridge effect config (multiplier/override)
- Version conflict handling (409 → "Modified by another user" banner with reload)

Closes #51

## Test plan
- [ ] Create new simple rule with mitigations, save successfully
- [ ] Create new conditional rule with multiple branches
- [ ] Create new computed rule with modifiers and value mappings
- [ ] Edit existing rule, verify fields populate correctly
- [ ] Switch type selector, verify config form resets
- [ ] Add/remove modifier rows, condition branches, mitigations
- [ ] Bridge mitigation requires effect; full mitigation has no effect config
- [ ] Simulate version conflict (409) — banner appears with reload option
- [ ] Cancel navigates back to rule list

🤖 Generated with [Claude Code](https://claude.com/claude-code)