### PR TITLE
Iteration 6.3: JSON editor with bidirectional sync

### DIFF
--- a/client/src/components/rules/json-editor.tsx
+++ b/client/src/components/rules/json-editor.tsx
@@ -1,0 +1,138 @@
+import { useState, useEffect, useRef } from 'react';
+import { RuleSchema } from '@shared/schemas/rule.schema.js';
+
+interface JsonEditorProps {
+  value: object;
+  onChange: (value: object) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Format Zod errors into readable strings
+// ---------------------------------------------------------------------------
+
+function formatZodIssues(issues: Array<{ path: (string | number)[]; message: string }>): string[] {
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    return `${path}: ${issue.message}`;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// JsonEditor
+// ---------------------------------------------------------------------------
+
+export function JsonEditor({ value, onChange }: JsonEditorProps) {
+  const [text, setText] = useState('');
+  const [errors, setErrors] = useState<string[]>([]);
+  const [validationResult, setValidationResult] = useState<'valid' | 'invalid' | null>(null);
+  const isExternalUpdate = useRef(false);
+
+  // Sync form → JSON when the form value changes externally
+  useEffect(() => {
+    isExternalUpdate.current = true;
+    setText(JSON.stringify(value, null, 2));
+    setErrors([]);
+    setValidationResult(null);
+  }, [value]);
+
+  function handleTextChange(newText: string) {
+    setText(newText);
+    setValidationResult(null);
+
+    // Try to parse and push to form
+    try {
+      const parsed = JSON.parse(newText);
+      setErrors([]);
+      onChange(parsed);
+    } catch {
+      setErrors(['Invalid JSON syntax']);
+    }
+  }
+
+  function handleFormat() {
+    try {
+      const parsed = JSON.parse(text);
+      setText(JSON.stringify(parsed, null, 2));
+      setErrors([]);
+    } catch {
+      setErrors(['Cannot format — invalid JSON syntax']);
+    }
+  }
+
+  function handleValidate() {
+    try {
+      const parsed = JSON.parse(text);
+      const result = RuleSchema.safeParse(parsed);
+      if (result.success) {
+        setErrors([]);
+        setValidationResult('valid');
+      } else {
+        setErrors(formatZodIssues(result.error.issues));
+        setValidationResult('invalid');
+      }
+    } catch {
+      setErrors(['Cannot validate — invalid JSON syntax']);
+      setValidationResult('invalid');
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-semibold text-gray-900">JSON Definition</h3>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleFormat}
+            className="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+          >
+            Format
+          </button>
+          <button
+            type="button"
+            onClick={handleValidate}
+            className="px-3 py-1.5 text-xs font-medium text-gray-500 bg-gray-100 rounded hover:bg-gray-200 transition-colors"
+          >
+            Validate
+          </button>
+        </div>
+      </div>
+
+      <textarea
+        value={text}
+        onChange={(e) => handleTextChange(e.target.value)}
+        rows={30}
+        spellCheck={false}
+        className="w-full font-mono text-sm rounded-md border border-gray-300 px-4 py-3 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-gray-50 resize-y"
+      />
+
+      {/* Validation result */}
+      {validationResult === 'valid' && errors.length === 0 && (
+        <div className="mt-3 rounded-md bg-green-50 border border-green-200 p-3">
+          <p className="text-sm text-green-700 font-medium flex items-center gap-1.5">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            Valid rule definition
+          </p>
+        </div>
+      )}
+
+      {/* Errors */}
+      {errors.length > 0 && (
+        <div className="mt-3 rounded-md bg-red-50 border border-red-200 p-3">
+          <p className="text-sm font-medium text-red-700 mb-1">
+            {errors.length} {errors.length === 1 ? 'error' : 'errors'} found
+          </p>
+          <ul className="space-y-0.5">
+            {errors.map((err, i) => (
+              <li key={i} className="text-xs text-red-600 font-mono">
+                {err}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/rules/editor.tsx
+++ b/client/src/pages/rules/editor.tsx
@@ -6,6 +6,7 @@ import { RuleFormSimple } from '@/components/rules/rule-form-simple';
 import { RuleFormConditional } from '@/components/rules/rule-form-conditional';
 import { RuleFormComputed } from '@/components/rules/rule-form-computed';
 import { MitigationEditor } from '@/components/rules/mitigation-editor';
+import { JsonEditor } from '@/components/rules/json-editor';
 import type { RuleType, SimpleConfig, ConditionalConfig, ComputedConfig, Mitigation } from '@shared/types/rule.js';
 
 // ---------------------------------------------------------------------------
@@ -41,6 +42,17 @@ const DEFAULT_CONFIGS: Record<RuleType, RuleConfig> = {
     comparisonOperator: 'gte',
   } as ComputedConfig,
 };
+
+function formToRuleObject(form: RuleFormState, id?: string): object {
+  return {
+    ...(id ? { id } : {}),
+    name: form.name,
+    description: form.description,
+    type: form.type,
+    config: form.config,
+    mitigations: form.mitigations,
+  };
+}
 
 function defaultFormState(): RuleFormState {
   return {
@@ -375,13 +387,20 @@ export function RuleEditorPage() {
         </>
       )}
 
-      {/* JSON View — placeholder for 6.3 */}
+      {/* JSON View */}
       {viewMode === 'json' && (
-        <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-6 mb-6">
-          <div className="text-center py-12 text-sm text-gray-500">
-            JSON Editor — coming in iteration 6.3
-          </div>
-        </div>
+        <JsonEditor
+          value={formToRuleObject(form, isNew ? undefined : id)}
+          onChange={(parsed) => {
+            const obj = parsed as any;
+            if (obj.name) setForm((prev) => ({ ...prev, name: obj.name }));
+            if (obj.description) setForm((prev) => ({ ...prev, description: obj.description }));
+            if (obj.type && obj.config) {
+              setForm((prev) => ({ ...prev, type: obj.type, config: obj.config }));
+            }
+            if (obj.mitigations) setForm((prev) => ({ ...prev, mitigations: obj.mitigations }));
+          }}
+        />
       )}
 
       {/* Actions */}


### PR DESCRIPTION
## Summary
- Add JSON editor component with Format and Validate buttons
- Bidirectional sync: form → JSON (on tab switch) and JSON → form (on valid parse)
- Zod validation via shared `RuleSchema` with inline field-level error display
- Green confirmation badge on valid rule definition
- Wired into rule editor, replacing placeholder

Closes #52

## Test plan
- [ ] Switch to JSON view — see formatted JSON matching form state
- [ ] Edit JSON, switch to Form view — form reflects JSON changes
- [ ] Edit form, switch to JSON view — JSON reflects form changes
- [ ] Click Format — JSON is pretty-printed
- [ ] Click Validate on valid rule — green "Valid rule definition" badge
- [ ] Click Validate on invalid rule — red error list with field paths
- [ ] Type invalid JSON syntax — shows "Invalid JSON syntax" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)