### PR TITLE
Fix: Release API returns snake_case (fixes Active Release counter)

### DIFF
--- a/server/src/__tests__/api/rules.test.ts
+++ b/server/src/__tests__/api/rules.test.ts
@@ -277,9 +277,9 @@ describe('Release Routes — /api/releases', () => {
     expect(res.status).toBe(201);
     expect(res.body.data).toMatchObject({
       name: 'v1.0',
-      isActive: false,
+      is_active: false,
     });
-    expect(res.body.data.releaseRules).toHaveLength(1);
+    expect(res.body.data.release_rules).toHaveLength(1);
   });
 
   it('10 - PUT /api/releases/:id/activate activates release', async () => {
@@ -300,7 +300,7 @@ describe('Release Routes — /api/releases', () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(200);
-    expect(res.body.data.isActive).toBe(true);
+    expect(res.body.data.is_active).toBe(true);
   });
 
   it('11 - GET /api/releases/active/rules returns rules from active release', async () => {

--- a/server/src/__tests__/api/smoke.test.ts
+++ b/server/src/__tests__/api/smoke.test.ts
@@ -240,7 +240,7 @@ describe('End-to-end smoke test', () => {
       .set('Authorization', `Bearer ${sciToken}`);
 
     expect(activateRes.status).toBe(200);
-    expect(activateRes.body.data.isActive).toBe(true);
+    expect(activateRes.body.data.is_active).toBe(true);
 
     // ── Step 9: Login as admin ──────────────────────────────────────────
     const adminLoginRes = await request(app)

--- a/server/src/services/release.service.ts
+++ b/server/src/services/release.service.ts
@@ -1,9 +1,33 @@
-import { releaseRepository } from '../db/repositories/release.repository.js';
+import { releaseRepository, type ReleaseWithRules } from '../db/repositories/release.repository.js';
 import { ruleRepository } from '../db/repositories/rule.repository.js';
 import { auditLogRepository } from '../db/repositories/audit-log.repository.js';
 import { defaultRegistry } from '../engine/engine.js';
 import { NotFoundError, ValidationError } from '../lib/errors.js';
-import type { Rule } from '@shared/types/rule.js';
+import type { Release } from '@prisma/client';
+
+/** Map a Prisma Release to consistent snake_case API format. */
+function toApiRelease(r: Release) {
+  return {
+    id: r.id,
+    name: r.name,
+    published_at: r.publishedAt.toISOString(),
+    published_by: r.publishedBy,
+    is_active: r.isActive,
+  };
+}
+
+/** Map a ReleaseWithRules to API format including release_rules. */
+function toApiReleaseWithRules(r: ReleaseWithRules) {
+  return {
+    ...toApiRelease(r),
+    release_rules: r.releaseRules.map((rr) => ({
+      id: rr.id,
+      release_id: rr.releaseId,
+      rule_id: rr.ruleId,
+      rule_snapshot: rr.ruleSnapshot,
+    })),
+  };
+}
 
 /**
  * Publish a new release by snapshotting all current draft rules.
@@ -40,7 +64,7 @@ export async function publish(name: string, userId: string) {
     { name, ruleCount: release.releaseRules.length },
   );
 
-  return release;
+  return toApiReleaseWithRules(release);
 }
 
 /**
@@ -63,7 +87,7 @@ export async function activate(id: string, userId: string) {
     { name: activated.name },
   );
 
-  return activated;
+  return toApiRelease(activated);
 }
 
 /**
@@ -107,19 +131,25 @@ export async function getActiveRules() {
 }
 
 /**
- * Get rules for a specific release.
+ * Get rules for a specific release, mapped to API format.
  */
 export async function getRulesForRelease(id: string) {
   const release = await releaseRepository.findByIdWithRules(id);
   if (!release) {
     throw new NotFoundError(`Release ${id} not found`);
   }
-  return release.releaseRules.map((rr) => rr.ruleSnapshot);
+  return release.releaseRules.map((rr) => ({
+    id: rr.id,
+    release_id: rr.releaseId,
+    rule_id: rr.ruleId,
+    rule_snapshot: rr.ruleSnapshot,
+  }));
 }
 
 /**
- * List all releases.
+ * List all releases, mapped to a consistent API format.
  */
 export async function list() {
-  return releaseRepository.list();
+  const releases = await releaseRepository.list();
+  return releases.map(toApiRelease);
 }


### PR DESCRIPTION
## Summary
- Release API endpoints (`list`, `publish`, `activate`, `getRulesForRelease`) now return consistent snake_case field names (`is_active`, `published_at`, `published_by`, `release_rules`)
- Previously returned camelCase from Prisma (`isActive`, `publishedAt`), causing the "Active Release" counter to show **0** after activation

## Root cause
`releases?.filter((r) => r.is_active)` returned empty because the API was sending `isActive` instead of `is_active`.

## Test plan
- [x] Server: 128/128 tests passing
- [ ] Manual: Activate a release → "Active Release" counter shows 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)