### PR TITLE
Fix: Rule reference search/filter not working

### DIFF
--- a/client/src/hooks/useRuleReference.ts
+++ b/client/src/hooks/useRuleReference.ts
@@ -23,15 +23,10 @@ export interface RuleSnapshot {
   mitigations: RuleSnapshotMitigation[];
 }
 
-export interface ActiveReleaseRulesResponse {
-  release_name: string;
-  rules: RuleSnapshot[];
-}
-
 export function useActiveReleaseRules() {
   return useQuery({
     queryKey: ['releases', 'active', 'rules'],
-    queryFn: () => apiClient.get<ActiveReleaseRulesResponse>('/releases/active/rules'),
+    queryFn: () => apiClient.get<RuleSnapshot[]>('/releases/active/rules'),
     staleTime: 60 * 1000,
   });
 }

--- a/client/src/pages/rule-reference/index.tsx
+++ b/client/src/pages/rule-reference/index.tsx
@@ -244,9 +244,9 @@ export function RuleReferencePage() {
   const [typeFilter, setTypeFilter] = useState('');
 
   const rules = useMemo(() => {
-    if (!data?.rules) return [];
+    if (!data) return [];
     const term = search.toLowerCase();
-    return data.rules.filter((rule) => {
+    return data.filter((rule) => {
       const matchesSearch =
         !term ||
         rule.name.toLowerCase().includes(term) ||
@@ -254,10 +254,9 @@ export function RuleReferencePage() {
       const matchesType = !typeFilter || rule.type === typeFilter;
       return matchesSearch && matchesType;
     });
-  }, [data?.rules, search, typeFilter]);
+  }, [data, search, typeFilter]);
 
-  const totalCount = data?.rules?.length ?? 0;
-  const releaseName = data?.release_name;
+  const totalCount = data?.length ?? 0;
 
   return (
     <div>
@@ -268,11 +267,10 @@ export function RuleReferencePage() {
             Browse all rules from the active release (read-only)
           </p>
         </div>
-        {releaseName && (
+        {totalCount > 0 && (
           <div className="flex items-center gap-3">
-            <span className="text-xs text-gray-400">Active Release:</span>
             <span className="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium bg-green-50 text-green-700 border border-green-200">
-              {releaseName} (Active)
+              Active Release
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary
Rule reference page showed no rules and search/filter did nothing.

**Root cause**: Hook typed API response as `{ release_name, rules }` but `GET /api/releases/active/rules` returns a flat `RuleSnapshot[]`. Component accessed `data.rules` → always `undefined`.

**Fix**: Changed hook return type to `RuleSnapshot[]`, updated component to use `data` directly.

## Test plan
- [ ] Navigate to /rule-reference — rules now display
- [ ] Type in search box — filters by name/description
- [ ] Use type dropdown — filters by rule type

🤖 Generated with [Claude Code](https://claude.com/claude-code)